### PR TITLE
feat : JPA가 UserPlaylist.java의 필드에 있는 Video 객체를 객체 타입이 아닌 JSON 혹은 TEX…

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
@@ -2,7 +2,9 @@ package com.zerobase.plistbackend.module.userplaylist.entity;
 
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import com.zerobase.plistbackend.module.userplaylist.util.VideoConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -38,5 +40,6 @@ public class UserPlaylist {
 
   @Lob
   @Column(name = "video")
+  @Convert(converter = VideoConverter.class)
   private Video video;
 }

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/VideoConverter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/VideoConverter.java
@@ -1,0 +1,31 @@
+package com.zerobase.plistbackend.module.userplaylist.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class VideoConverter implements AttributeConverter<Video, String> {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(Video video) {
+    try {
+      return mapper.writeValueAsString(video);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Could not convert Video to JSON", e);
+    }
+  }
+
+  @Override
+  public Video convertToEntityAttribute(String json) {
+    try {
+      return mapper.readValue(json, Video.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error converting JSON to Video", e);
+    }
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
UserPlaylist Entity가 Video 객체를 TEXT or JSON 타입으로 인식하지 못해 매핑이 안됐었습니다.
**TO-BE**
JPA의 Converter 기능을 활용해서 Video 객체가 UserPlaylist 테이블에 저장 및 업데이트 시에는 자동으로 JSON or TEXT 타입으로 직렬화를 통해 Table에 저장될 수 있도록, 그리고 UserPlaylist Table에서 Video 조회 시에는 JSON or TEXT가 아닌 Video 객체로 자동으로 변환되어 조회 되도록 해줍니다.  
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
