### PR TITLE
Feature/create userplaylist

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/common/app/config/YouTubeApiProperties.java
+++ b/src/main/java/com/zerobase/plistbackend/common/app/config/YouTubeApiProperties.java
@@ -9,15 +9,17 @@ public class YouTubeApiProperties {
   private final String url;
   private final String type;
   private final String part;
-  private final long maxResults;
+  private final int maxResults;
   private final String order;
   private final String relevanceLanguage;
   private final String videoEmbeddable;
+  private final String topicId;
   private final String apiKey;
 
+
   public YouTubeApiProperties(String url, String type, String part,
-      long maxResults, String order, String relevanceLanguage,
-      String videoEmbeddable, String apiKey) {
+      int maxResults, String order, String relevanceLanguage,
+      String videoEmbeddable, String topicId, String apiKey) {
     this.url = url;
     this.type = type;
     this.part = part;
@@ -25,6 +27,7 @@ public class YouTubeApiProperties {
     this.order = order;
     this.relevanceLanguage = relevanceLanguage;
     this.videoEmbeddable = videoEmbeddable;
+    this.topicId = topicId;
     this.apiKey = apiKey;
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/home/controller/HomeController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/home/controller/HomeController.java
@@ -6,19 +6,21 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v3/api")
 @RequiredArgsConstructor
 public class HomeController {
 
   private final HomeService homeService;
 
-  @GetMapping("/service/search")
-  public ResponseEntity<List<VideoResponse>> searchVideo(@RequestParam("searchValue") String searchValue) {
+  @GetMapping("/search-video")
+  public ResponseEntity<List<VideoResponse>> searchVideo(@RequestParam("keyword") String keyword) {
 
-    List<VideoResponse> videoResponseList = homeService.searchVideo(searchValue);
+    List<VideoResponse> videoResponseList = homeService.searchVideo(keyword);
 
     return ResponseEntity.ok(videoResponseList);
   }

--- a/src/main/java/com/zerobase/plistbackend/module/home/service/HomeService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/home/service/HomeService.java
@@ -5,5 +5,5 @@ import java.util.List;
 
 public interface HomeService {
 
-  List<VideoResponse> searchVideo(String searchValue);
+  List<VideoResponse> searchVideo(String keyword);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/participant/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/participant/dto/response/ParticipantResponse.java
@@ -1,0 +1,30 @@
+package com.zerobase.plistbackend.module.participant.dto.response;
+
+import com.zerobase.plistbackend.module.participant.entity.Participant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParticipantResponse {
+
+  private Long participantId;
+  private Long userId;
+  private Long channelId;
+  private boolean isHost;
+
+  public static ParticipantResponse createParticipantResponse(Participant participant) {
+    return ParticipantResponse.builder()
+        .participantId(participant.getParticipantId())
+        .userId(participant.getUser().getUserId())
+        .channelId(participant.getChannel().getChannelId())
+        .isHost(participant.getIsHost())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/dto/UserDto.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/dto/UserDto.java
@@ -1,0 +1,42 @@
+package com.zerobase.plistbackend.module.user.dto;
+
+import com.zerobase.plistbackend.module.participant.dto.response.ParticipantResponse;
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.user.type.UserRole;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDto {
+
+  private Long userId;
+  private String userEmail;
+  private String userName;
+  private Timestamp userCreatedAt;
+  private Timestamp userUpdatedAt;
+  private UserRole userRole;
+  private String userImage;
+  private List<ParticipantResponse> participants;
+
+  public static UserDto from(User user) {
+    List<ParticipantResponse> participantResponseList = user.getParticipants().stream()
+        .map(ParticipantResponse::createParticipantResponse).toList();
+    return UserDto.builder()
+        .userId(user.getUserId())
+        .userEmail(user.getUserEmail())
+        .userName(user.getUserName())
+        .userCreatedAt(user.getUserCreatedAt())
+        .userUpdatedAt(user.getUserUpdatedAt())
+        .userRole(user.getUserRole())
+        .userImage(user.getUserImage())
+        .participants(participantResponseList)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/controller/UserPlaylistController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/controller/UserPlaylistController.java
@@ -1,0 +1,92 @@
+package com.zerobase.plistbackend.module.userplaylist.controller;
+
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
+import com.zerobase.plistbackend.module.userplaylist.service.UserPlaylistService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v3/api")
+public class UserPlaylistController {
+
+  private final UserPlaylistService userPlaylistService;
+
+  @PostMapping("/user/playlist")
+  public ResponseEntity<UserPlaylistResponse> createUserPlaylist(
+      @RequestBody String userPlaylistName,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    UserPlaylistResponse userPlaylistResponse = userPlaylistService.createUserPlayList(
+        userPlaylistName,
+        customOAuth2User);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(userPlaylistResponse);
+  }
+
+  @GetMapping("/user/playlists")
+  public ResponseEntity<List<UserPlaylistResponse>> findAllUserPlaylist(
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    List<UserPlaylistResponse> userPlaylistResponseList = userPlaylistService.findAllUserPlaylist(
+        customOAuth2User);
+
+    return ResponseEntity.ok(userPlaylistResponseList);
+  }
+
+  @GetMapping("/user/playlist/{userPlaylistId}")
+  public ResponseEntity<UserPlaylistResponse> findOneUserPlaylist(
+      @PathVariable Long userPlaylistId,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    UserPlaylistResponse userPlaylistResponse = userPlaylistService.findOneUserPlaylist(
+        userPlaylistId, customOAuth2User);
+
+    return ResponseEntity.ok(userPlaylistResponse);
+  }
+
+  @DeleteMapping("/user/playlist/{userPlaylistId}")
+  public void deleteUserPlaylist(@PathVariable Long userPlaylistId,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    userPlaylistService.deleteUserPlaylist(userPlaylistId, customOAuth2User);
+  }
+
+  @PatchMapping("/user/playlist/{userPlaylistId}/add")
+  public ResponseEntity<UserPlaylistResponse> addVideoToUserPlaylist(
+      @PathVariable Long userPlaylistId,
+      @RequestBody VideoRequest videoRequest,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    UserPlaylistResponse userPlaylistResponse = userPlaylistService.addVideo(customOAuth2User,
+        userPlaylistId, videoRequest);
+
+    return ResponseEntity.ok(userPlaylistResponse);
+  }
+
+  @PatchMapping("/user/playlist/{userPlaylistId}/remove")
+  public ResponseEntity<UserPlaylistResponse> removeVideoToUserPlaylist(
+      @PathVariable Long userPlaylistId,
+      @RequestParam("id") Long id,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    UserPlaylistResponse userPlaylistResponse = userPlaylistService.removeVideo(customOAuth2User,
+        userPlaylistId, id);
+
+    return ResponseEntity.ok(userPlaylistResponse);
+  }
+
+  // TODO: 유저플레이리스트 순서 변경.
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/dto/request/VideoRequest.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/dto/request/VideoRequest.java
@@ -1,0 +1,21 @@
+package com.zerobase.plistbackend.module.userplaylist.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoRequest {
+
+  @JsonProperty("videoId")
+  private String videoId;
+  @JsonProperty("videoName")
+  private String videoName;
+  @JsonProperty("videoThumbnail")
+  private String videoThumbnail;
+  @JsonProperty("videoDescription")
+  private String videoDescription;
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/dto/response/UserPlaylistResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/dto/response/UserPlaylistResponse.java
@@ -1,0 +1,30 @@
+package com.zerobase.plistbackend.module.userplaylist.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobase.plistbackend.module.user.dto.UserDto;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
+import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public class UserPlaylistResponse {
+
+  @JsonProperty("userPlaylistId")
+  private Long userPlaylistId;
+  @JsonProperty("userDto")
+  private UserDto userDto;
+  @JsonProperty("userPlaylistName")
+  private String userPlaylistName;
+  @JsonProperty("videoList")
+  private List<Video> videoList;
+
+  public static UserPlaylistResponse from(UserPlaylist userPlaylist) {
+    return UserPlaylistResponse.builder()
+        .userPlaylistId(userPlaylist.getUserPlaylistId())
+        .userDto(UserDto.from(userPlaylist.getUser()))
+        .userPlaylistName(userPlaylist.getUserPlaylistName())
+        .videoList(userPlaylist.getVideoList())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
@@ -1,5 +1,6 @@
 package com.zerobase.plistbackend.module.userplaylist.entity;
 
+import com.zerobase.plistbackend.module.playlist.entity.Playlist;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.userplaylist.model.Video;
 import com.zerobase.plistbackend.module.userplaylist.util.UserPlaylistVideoConverter;
@@ -14,13 +15,18 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @Table(name = "userplaylist")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,11 +41,28 @@ public class UserPlaylist {
   @JoinColumn(name = "user_id")
   private User user;
 
-  @Column(name = "userplaylist_name")
+  @Column(name = "userplaylist_name", length = 30)
   private String userPlaylistName;
 
   @Lob
-  @Column(name = "video")
+  @Column(name = "video", columnDefinition = "LONGTEXT")
   @Convert(converter = UserPlaylistVideoConverter.class)
-  private Video video;
+  private List<Video> videoList;
+
+  public static UserPlaylist createUserPlaylist(User user, String userPlaylistName) {
+    return UserPlaylist.builder()
+        .user(user)
+        .userPlaylistName(userPlaylistName)
+        .videoList(new ArrayList<>())
+        .build();
+  }
+
+  public static UserPlaylist fromChannelPlaylist (User user, Playlist playlist) {
+    String uuid = UUID.randomUUID().toString();
+    return UserPlaylist.builder()
+        .user(user)
+        .userPlaylistName("Playlist_" + uuid)
+        .videoList(playlist.getVideoList())
+        .build();
+  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/model/Video.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/model/Video.java
@@ -1,14 +1,45 @@
 package com.zerobase.plistbackend.module.userplaylist.model;
 
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class Video {
 
-  private final String videoName;
-  private final String videoThumbnail;
-  private final String videoId;
+  private Long id;
+  private String videoName;
+  private String videoThumbnail;
+  private String videoId;
+  private String videoDescription;
 
+  public static Video createVideo (VideoRequest videoRequest, List<Video> videoList) {
+
+    Long increased_id = init(videoList);
+
+    return Video.builder()
+        .id(increased_id)
+        .videoName(videoRequest.getVideoName())
+        .videoThumbnail(videoRequest.getVideoThumbnail())
+        .videoId(videoRequest.getVideoId())
+        .videoDescription(videoRequest.getVideoDescription())
+        .build();
+  }
+
+  private static Long init(List<Video> videoList) {
+    long id = 1L;
+    if (videoList.isEmpty()) {
+      return id;
+    } else {
+      Video video = videoList.get(videoList.size() - 1);
+      id = video.getId() + 1;
+      return id;
+    }
+  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/repository/UserPlaylistRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/repository/UserPlaylistRepository.java
@@ -1,0 +1,17 @@
+package com.zerobase.plistbackend.module.userplaylist.repository;
+
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPlaylistRepository extends JpaRepository<UserPlaylist, Long> {
+
+  UserPlaylist findByUserAndUserPlaylistId(User user, Long userPlaylistId);
+
+  List<UserPlaylist> findByUser(User user);
+
+  void deleteByUserAndUserPlaylistId(User user, Long userPlaylistId);
+
+  boolean existsByUserAndUserPlaylistId(User user, Long userPlaylistId);
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/service/UserPlaylistService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/service/UserPlaylistService.java
@@ -1,0 +1,21 @@
+package com.zerobase.plistbackend.module.userplaylist.service;
+
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
+import java.util.List;
+
+public interface UserPlaylistService {
+
+  UserPlaylistResponse createUserPlayList(String userPlaylistName, CustomOAuth2User customOAuth2User);
+
+  UserPlaylistResponse findOneUserPlaylist(Long userPlaylistId, CustomOAuth2User customOAuth2User);
+
+  List<UserPlaylistResponse> findAllUserPlaylist(CustomOAuth2User customOAuth2User);
+
+  UserPlaylistResponse addVideo(CustomOAuth2User customOAuth2User, Long userPlaylistId, VideoRequest videoRequest);
+
+  UserPlaylistResponse removeVideo(CustomOAuth2User customOAuth2User, Long userPlaylistId, Long id);
+
+  void deleteUserPlaylist(Long userPlaylistId, CustomOAuth2User customOAuth2User);
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/service/UserPlaylistServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/service/UserPlaylistServiceImpl.java
@@ -1,0 +1,114 @@
+package com.zerobase.plistbackend.module.userplaylist.service;
+
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
+import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import com.zerobase.plistbackend.module.userplaylist.repository.UserPlaylistRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserPlaylistServiceImpl implements UserPlaylistService {
+
+  private final UserPlaylistRepository userPlaylistRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public UserPlaylistResponse createUserPlayList(String userPlaylistName,
+      CustomOAuth2User customOAuth2User) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+
+    //2. 유저플레이리스트네임으로 유저플레이리스트 생성 (Video 는 빈배열로 생성)
+    UserPlaylist userPlaylist = UserPlaylist.createUserPlaylist(user, userPlaylistName);
+    userPlaylistRepository.save(userPlaylist);
+
+    //3. 생성된 유저플레이리스트 반환.
+    return UserPlaylistResponse.from(userPlaylist);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<UserPlaylistResponse> findAllUserPlaylist(CustomOAuth2User customOAuth2User) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 유저 정보를 통해 유저플레이리스트 조회
+    List<UserPlaylist> userPlaylists = userPlaylistRepository.findByUser(user);
+    //3. List<userPlaylistResponse>로 반환.
+    return userPlaylists.stream().map(UserPlaylistResponse::from).collect(Collectors.toList());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public UserPlaylistResponse findOneUserPlaylist(Long userPlaylistId,
+      CustomOAuth2User customOAuth2User) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 유저 플레이리스트ID 와 유저 정보를 통해 userPlaylist 가져오기.
+    UserPlaylist userPlaylist = userPlaylistRepository.findByUserAndUserPlaylistId(user,
+        userPlaylistId);
+    //3. userPlaylistResponse로 반환.
+    return UserPlaylistResponse.from(userPlaylist);
+  }
+
+  @Override
+  @Transactional
+  public void deleteUserPlaylist(Long userPlaylistId, CustomOAuth2User customOAuth2User) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 유저 플레이리스트ID와 유저 정보를 통해 userPlaylist 삭제하기.
+    if (userPlaylistRepository.existsByUserAndUserPlaylistId(user, userPlaylistId)) {
+      userPlaylistRepository.deleteByUserAndUserPlaylistId(user, userPlaylistId);
+    } else {
+      throw new RuntimeException("해당 유저플레이리스트가 존재하지 않습니다.");
+    }
+  }
+
+  @Override
+  @Transactional
+  public UserPlaylistResponse addVideo(CustomOAuth2User customOAuth2User, Long userPlaylistId,
+      VideoRequest videoRequest) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 유저 플레이리스트ID와 유저 정보를 통해 userPlaylist 가져오기
+    UserPlaylist userPlaylist = userPlaylistRepository.findByUserAndUserPlaylistId(user,
+        userPlaylistId);
+    //3. VideoRequest를 Video 객체로 변환
+    Video video = Video.createVideo(videoRequest, userPlaylist.getVideoList());
+    //4. userPlaylist 의 VideoList 에 Video 객체 추가
+    userPlaylist.getVideoList().add(video);
+    userPlaylistRepository.save(userPlaylist);
+    //5. userPlaylistResponse로 반환.
+    return UserPlaylistResponse.from(userPlaylist);
+  }
+
+  @Override
+  @Transactional
+  public UserPlaylistResponse removeVideo(CustomOAuth2User customOAuth2User, Long userPlaylistId,
+      Long id) {
+    //1. 현재 로그인 중인 유저의 정보 받아오기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 유저 플레이리스트ID와 유저 정보를 통해 userPlaylist 가져오기
+    UserPlaylist userPlaylist = userPlaylistRepository.findByUserAndUserPlaylistId(user,
+        userPlaylistId);
+    //3. userPlaylist의 VideoList 가져오기.
+    List<Video> videoList = userPlaylist.getVideoList();
+    //4. VideoList에서 videoId와 같은 값 제거.
+    Video video = videoList.stream().filter(it -> it.getId().equals(id)).findFirst()
+        .orElseThrow(() -> new RuntimeException("해당하는 비디오가 없습니다."));
+    videoList.remove(video);
+    //5. userPlaylist 다시 저장
+    userPlaylistRepository.save(userPlaylist);
+    //6. userPlaylistResponse로 반환.
+    return UserPlaylistResponse.from(userPlaylist);
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/UserPlaylistVideoConverter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/UserPlaylistVideoConverter.java
@@ -5,27 +5,29 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.plistbackend.module.userplaylist.model.Video;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Converter
 @RequiredArgsConstructor
-public class UserPlaylistVideoConverter implements AttributeConverter<Video, String> {
+public class UserPlaylistVideoConverter implements AttributeConverter<List<Video>, String> {
 
   private final ObjectMapper mapper;
 
   @Override
-  public String convertToDatabaseColumn(Video video) {
+  public String convertToDatabaseColumn(List<Video> videoList) {
     try {
-      return mapper.writeValueAsString(video);
+      return mapper.writeValueAsString(videoList);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Could not convert Video to JSON", e);
     }
   }
 
   @Override
-  public Video convertToEntityAttribute(String json) {
+  public List<Video> convertToEntityAttribute(String json) {
     try {
-      return mapper.readValue(json, Video.class);
+      return mapper.readValue(json,
+          mapper.getTypeFactory().constructCollectionType(List.class, Video.class));
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Error converting JSON to Video", e);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,11 +34,12 @@ spring:
     secret: ${jwt_secret}
 
 youtube-api:
-  url: "https://www.googleapis.com/youtube/v3/search?key=%s&q=%s&type=%s&part=%s&maxResults=%d&order=%s&relevanceLanguage=%s&videoEmbeddable=%s"
+  url: "https://www.googleapis.com/youtube/v3/search?key=%s&q=%s&type=%s&part=%s&order=%s&relevanceLanguage=%s&videoEmbeddable=%s&maxResults=%d&topicId=%s"
   type: "video" # 검색할 타입
   part: "snippet" # 응답에 포함될 내용
   maxResults: 50 # 페이지 당 보여주는 응답 갯수 범위 0~50
   order: "viewCount" # 조회수가 많은 순서대로 정렬
   relevanceLanguage: "ko" # 가장 관련있는 언어로 검색
   videoEmbeddable: "true" # 웹 페이지에서 재생가능한 동영상만 검색
+  topicId: "/m/04rlf" # 검색 결과를 음악으로 제한함
   apiKey: ${youtube_api_key} # 자신의 API 키


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 유저 플레이리스트 기능 부재.
- 유튜브 API 검색 음악으로 제한.
**TO-BE**
- 유저 플레이리스트 기능 구현
  - 유저 플레이리스트 생성
    - 입력값 : 유저 플레이리스트 이름
 - 유저 플레이리스트 전체조회
 - 유저 플레이리스트 상세조회(단건)
   - 유저 플레이리스트 Id값으로 조회
 - 유저 플레이리스트 삭제(단건)
   - 유저 플레이리스트 Id값으로 삭제
 - 유저 플레이리스트 영상 추가
 - 유저 플레이리스트 영상 삭제
   -  현재 추가 되어 있는 영상의 Id값으로 삭제
 
- 유튜브 API를 통해 검색된 결과가 음악으로만 제한되도록 topidId 파라미터 추가

- Response 생성 및 수정

- 유저 플레이리스트 Entity 수정
  - 유저 플레이리스트의 Video 컬럼은 List<Video>로 저장되어야 하기때문에 변경. 변경에 따라 Converter 또한 리스트형태를 저장하도록 변경
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
  - PostMan을 활용해 Cookie에 토큰값을 주입하고 API 테스트 시 응답값 확인 완료.

- 추가해야할 것
  - Try-catch문 어노테이션으로 변경
  - 테스트코드 작성