### PR TITLE
Feature/create channel v2

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/controller/ChannelController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/controller/ChannelController.java
@@ -3,27 +3,37 @@ package com.zerobase.plistbackend.module.channel.controller;
 import com.zerobase.plistbackend.module.channel.dto.request.ChannelRequest;
 import com.zerobase.plistbackend.module.channel.dto.response.ChannelResponse;
 import com.zerobase.plistbackend.module.channel.service.ChannelService;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/v3/api")
 public class ChannelController {
 
   private final ChannelService channelService;
 
-  @PostMapping("/channel") // TODO : Principal 본인이 채널 참가자로 등록되게 해야함.
-  public ResponseEntity<ChannelResponse> addChannel(@RequestBody ChannelRequest channelRequest) {
-    ChannelResponse channelResponse = channelService.addChannel(channelRequest);
+  @PostMapping("/channel")
+  // TODO : Principal 본인이 채널 참가자로 등록되게 해야함. || 채널 생성 시 호스트가 재생목록을 추가하면 추가되도록 해야함.
+  public ResponseEntity<ChannelResponse> addChannel(
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @RequestBody ChannelRequest channelRequest) {
+
+    ChannelResponse channelResponse = channelService.addChannel(customOAuth2User, channelRequest);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(channelResponse);
   }
@@ -35,21 +45,82 @@ public class ChannelController {
     return ResponseEntity.ok(channelResponseList);
   }
 
-  @GetMapping("/channels/{channelName}")
+  // TODO : 채널 아이디값으로 채널 검색.
+
+  // TODO : 홈에서 채널 검색할 시, 호스트네임, 카테고리, 채널명까지 포함해서 검색결과 반환.
+
+  @GetMapping("/channels/channel-name")
   public ResponseEntity<List<ChannelResponse>> findChannelFromChannelName(
-      @PathVariable String channelName) {
+      @RequestParam("searchValue") String channelName) {
     List<ChannelResponse> channelResponseList = channelService.findChannelFromChannelName(
         channelName);
 
     return ResponseEntity.ok(channelResponseList);
-  }
+  } // TODO : 합쳐질 예정
 
-  @GetMapping("/channels/{channelCategory}")
+  @GetMapping("/channels/channel-category")
   public ResponseEntity<List<ChannelResponse>> findChannelFromChannelCategory(
-      @PathVariable String channelCategory) {
+      @RequestParam("searchValue") String channelCategory) {
     List<ChannelResponse> channelResponseList = channelService.findChannelFromChannelCategory(
         channelCategory);
 
     return ResponseEntity.ok(channelResponseList);
+  } // TODO : 카테고리 네임 -> 카테고리 ID로 검색
+
+  @PatchMapping("/channel/{channelId}")
+  public void enterChannel(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @PathVariable Long channelId) {
+
+    channelService.enterChannel(customOAuth2User, channelId);
   }
+
+  @PatchMapping("/channel/exit/{channelId}")
+  public void userExitChannel(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @PathVariable Long channelId) {
+
+    channelService.userExitChannel(customOAuth2User, channelId);
+  }
+
+  @PatchMapping("/channel/destroy/{channelId}")
+  public void hostExitChannel(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @PathVariable Long channelId) {
+
+    channelService.hostExitChannel(customOAuth2User, channelId);
+  }
+
+  @PatchMapping("/channel/{channelId}/add-video")
+  public ResponseEntity<ChannelResponse> addVideoToChannel(@PathVariable Long channelId,
+      @RequestBody VideoRequest videoRequest,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    ChannelResponse channelResponse = channelService.addVideoToChannel(channelId, videoRequest,
+        customOAuth2User);
+
+    return ResponseEntity.ok(channelResponse);
+  }
+
+  @PatchMapping("/channel/{channelId}/delete-video")
+  public ResponseEntity<ChannelResponse> deleteVideoToChannel(@PathVariable Long channelId,
+      @RequestParam("id") Long id, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+    ChannelResponse channelResponse = channelService.deleteVideoToChannel(channelId, id,
+        customOAuth2User);
+
+    return ResponseEntity.ok(channelResponse);
+  }
+
+  @PostMapping("/channel/{channelId}/save-playlist")
+  public ResponseEntity<UserPlaylistResponse> savePlaylistToUserPlaylist(
+      @PathVariable Long channelId,
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    UserPlaylistResponse userPlaylistResponse = channelService.savePlaylistToUserPlaylist(channelId,
+        customOAuth2User);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(userPlaylistResponse);
+  }
+
+  //TODO : 특정 채널 플레이리스트 목록 조회.
+  //TODO : 채널 플레이리스트 순서 변경.
 }
+
+

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/request/ChannelRequest.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/request/ChannelRequest.java
@@ -1,18 +1,14 @@
 package com.zerobase.plistbackend.module.channel.dto.request;
 
-import com.zerobase.plistbackend.module.playlist.entity.Playlist;
-import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.Range;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChannelRequest {
 
-  @Range(min=1, max = 50)
   private String channelName;
   private Long userPlaylistId;
   private String channelCategory;

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/request/ChannelRequest.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/request/ChannelRequest.java
@@ -1,15 +1,20 @@
 package com.zerobase.plistbackend.module.channel.dto.request;
 
+import com.zerobase.plistbackend.module.playlist.entity.Playlist;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChannelRequest {
 
+  @Range(min=1, max = 50)
   private String channelName;
+  private Long userPlaylistId;
   private String channelCategory;
   private String channelThumbnail;
   private Long channelCapacity;

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/ChannelResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/ChannelResponse.java
@@ -1,9 +1,11 @@
 package com.zerobase.plistbackend.module.channel.dto.response;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
-import com.zerobase.plistbackend.module.participant.entity.Participant;
-import com.zerobase.plistbackend.module.playlist.entity.Playlist;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
+import com.zerobase.plistbackend.module.participant.dto.response.ParticipantResponse;
+import com.zerobase.plistbackend.module.playlist.dto.response.PlaylistResponse;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,12 +27,14 @@ public class ChannelResponse {
   private Timestamp channelCreatedAt;
   private Timestamp channelFinishedAt;
   private Long channelCapacity;
-  private boolean channelStatus;
-  private List<Playlist> channelPlaylists;
-  private List<Participant> channelParticipants;
+  private ChannelStatus channelStatus;
+  private PlaylistResponse channelPlaylist;
+  private List<ParticipantResponse> channelParticipants;
 
 
-  public static ChannelResponse createChannelResponse(Channel channel) {
+  public static ChannelResponse createChannelResponse(Channel channel,
+      PlaylistResponse playlistResponse,
+      List<ParticipantResponse> participantResponseList) {
     return ChannelResponse.builder()
         .channelId(channel.getChannelId())
         .channelName(channel.getChannelName())
@@ -39,9 +43,26 @@ public class ChannelResponse {
         .channelCreatedAt(channel.getChannelCreatedAt())
         .channelFinishedAt(channel.getChannelFinishedAt())
         .channelCapacity(channel.getChannelCapacity())
-        .channelStatus(channel.isChannelStatus())
-        .channelPlaylists(channel.getChannelPlaylists())
-        .channelParticipants(channel.getChannelParticipants())
+        .channelStatus(channel.getChannelStatus())
+        .channelPlaylist(playlistResponse)
+        .channelParticipants(participantResponseList)
         .build();
+  }
+
+  public static List<ChannelResponse> createChannelResponseList(List<Channel> channelList) {
+    List<ChannelResponse> channelResponseList = new ArrayList<>();
+
+    for (Channel channel : channelList) {
+      List<ParticipantResponse> participantResponseList = channel.getChannelParticipants().stream()
+          .map(
+              ParticipantResponse::createParticipantResponse).toList();
+      PlaylistResponse playlistResponse = PlaylistResponse.from(channel.getChannelPlaylist());
+      ChannelResponse channelResponse = ChannelResponse.createChannelResponse(channel,
+          playlistResponse,
+          participantResponseList);
+      channelResponseList.add(channelResponse);
+    }
+
+    return channelResponseList;
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -1,14 +1,15 @@
 package com.zerobase.plistbackend.module.channel.repository;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
-  List<Channel> findAllByChannelStatus(boolean b);
+  List<Channel> findAllByChannelStatus(ChannelStatus channelStatus);
 
-  List<Channel> findByChannelStatusAndChannelNameLike(boolean b, String channelName);
+  List<Channel> findByChannelStatusAndChannelNameContaining(ChannelStatus channelStatus, String channelName);
 
-  List<Channel> findByChannelStatusAndChannelCategory(boolean b, String channelCategory);
+  List<Channel> findByChannelStatusAndChannelCategory(ChannelStatus channelStatus, String channelCategory);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelService.java
@@ -2,17 +2,32 @@ package com.zerobase.plistbackend.module.channel.service;
 
 import com.zerobase.plistbackend.module.channel.dto.request.ChannelRequest;
 import com.zerobase.plistbackend.module.channel.dto.response.ChannelResponse;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
 import java.util.List;
 
 public interface ChannelService {
 
-  ChannelResponse addChannel(ChannelRequest channelRequest);
+  ChannelResponse addChannel(CustomOAuth2User customOAuth2User, ChannelRequest channelRequest);
 
   List<ChannelResponse> findChannelList();
 
   List<ChannelResponse> findChannelFromChannelName(String channelName);
 
   List<ChannelResponse> findChannelFromChannelCategory(String channelCategory);
+
+  void enterChannel(CustomOAuth2User customOAuth2User, Long channelId);
+
+  void userExitChannel(CustomOAuth2User customOAuth2User, Long channelId);
+
+  void hostExitChannel(CustomOAuth2User customOAuth2User, Long channelId);
+
+  ChannelResponse addVideoToChannel(Long channelId, VideoRequest videoRequest, CustomOAuth2User customOAuth2User);
+
+  ChannelResponse deleteVideoToChannel(Long channelId, Long id, CustomOAuth2User customOAuth2User);
+
+  UserPlaylistResponse savePlaylistToUserPlaylist(Long channelId, CustomOAuth2User customOAuth2User);
 
 //
 //  Object addVideoToPlaylistItem();

--- a/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelServiceImpl.java
@@ -4,6 +4,22 @@ import com.zerobase.plistbackend.module.channel.dto.request.ChannelRequest;
 import com.zerobase.plistbackend.module.channel.dto.response.ChannelResponse;
 import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
+import com.zerobase.plistbackend.module.participant.dto.response.ParticipantResponse;
+import com.zerobase.plistbackend.module.participant.entity.Participant;
+import com.zerobase.plistbackend.module.participant.repository.ParticipantRepository;
+import com.zerobase.plistbackend.module.playlist.dto.response.PlaylistResponse;
+import com.zerobase.plistbackend.module.playlist.entity.Playlist;
+import com.zerobase.plistbackend.module.playlist.repository.PlaylistRepository;
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
+import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
+import com.zerobase.plistbackend.module.userplaylist.dto.response.UserPlaylistResponse;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
+import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import com.zerobase.plistbackend.module.userplaylist.repository.UserPlaylistRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,43 +31,215 @@ public class ChannelServiceImpl implements ChannelService {
 
   // 웹 페이지에서 재생가능한 동영상만 검색
   private final ChannelRepository channelRepository;
-
+  private final UserRepository userRepository;
+  private final ParticipantRepository participantRepository;
+  private final UserPlaylistRepository userPlaylistRepository;
+  private final PlaylistRepository playlistRepository;
 
   @Override
   @Transactional
-  public ChannelResponse addChannel(ChannelRequest channelRequest) {
+  public ChannelResponse addChannel(CustomOAuth2User customOAuth2User,
+      ChannelRequest channelRequest) {
+    // TODO: 카테고리 생성 후 카테고리 요청 받는 작업 // 채널을 이미 생성한 경우, 채널을 생성할 수 없게 하는 로직.
 
-    Channel channel = Channel.createChannel(channelRequest);
-
+    //1. 현재 로그인 되어 있는 사용자 찾기
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //1-1. 현재 로그인 되어 있는 User가 생성한 방이 있으면 예외 발생.
+    List<Participant> userParticipantList = participantRepository.findByUser(user);
+    if (userParticipantList.stream().anyMatch(it-> it.getIsHost().equals(true))) {
+      throw new RuntimeException("이미 생성한 방이 존재합니다."); // TODO: 예외처리
+    }
+    //2. 사용자의 userplaylist id값으로 Playlist 객체 생성 (없으면 빈 객체 생성)
+    Playlist playlist = new Playlist();
+    if (channelRequest.getUserPlaylistId() != null) {
+      UserPlaylist userPlaylist = userPlaylistRepository.findByUserAndUserPlaylistId(user,
+          channelRequest.getUserPlaylistId());
+      playlist = Playlist.from(userPlaylist);
+    } else {
+      playlist.setVideoList(new ArrayList<>());
+    }
+    //3. 두개를 이용해서 채널 생성
+    Channel channel = Channel.createChannel(channelRequest, playlist);
+    //3-1. Playlist에 채널 추가.
+    playlist.setChannel(channel);
+    //4. 채널의 참가자에 User를 변환한 Participant 추가 (HOST)
+    Participant participant = Participant.host(user, channel);
+    channel.getChannelParticipants().add(participant);
+    //5. 채널 저장 // 참가자 저장? // 플레이리스트 저장?
+    participantRepository.save(participant);
+    playlistRepository.save(playlist);
     channelRepository.save(channel);
+    //6. 채널을 DTO로 변환해서 리턴시킴.
+    List<ParticipantResponse> participantResponseList = channel.getChannelParticipants().stream()
+        .map(
+            ParticipantResponse::createParticipantResponse).toList();
+    PlaylistResponse playlistResponse = PlaylistResponse.from(playlist);
 
-    return ChannelResponse.createChannelResponse(channel);
+    return ChannelResponse.createChannelResponse(channel, playlistResponse,
+        participantResponseList);
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<ChannelResponse> findChannelList() {
-    List<Channel> channelList = channelRepository.findAllByChannelStatus(true);
+    List<Channel> channelList = channelRepository.findAllByChannelStatus(
+        ChannelStatus.CHANNEL_STATUS_ACTIVE);
 
-    return channelList.stream().map(
-        ChannelResponse::createChannelResponse).toList();
+    return ChannelResponse.createChannelResponseList(channelList);
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<ChannelResponse> findChannelFromChannelName(String channelName) {
-    List<Channel> channelList = channelRepository.findByChannelStatusAndChannelNameLike(true,
-        channelName);// TODO : 예외처리
+    List<Channel> channelList = channelRepository.findByChannelStatusAndChannelNameContaining(
+        ChannelStatus.CHANNEL_STATUS_ACTIVE,
+        channelName);
 
-    return channelList.stream().map(ChannelResponse::createChannelResponse).toList();
+    return ChannelResponse.createChannelResponseList(channelList);
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<ChannelResponse> findChannelFromChannelCategory(String channelCategory) {
-    List<Channel> channelList = channelRepository.findByChannelStatusAndChannelCategory(true,
-        channelCategory);// TODO : 예외처리
+    List<Channel> channelList = channelRepository.findByChannelStatusAndChannelCategory(
+        ChannelStatus.CHANNEL_STATUS_ACTIVE,
+        channelCategory);
 
-    return channelList.stream().map(ChannelResponse::createChannelResponse).toList();
+    return ChannelResponse.createChannelResponseList(channelList);
+  }
+
+
+  @Override
+  @Transactional
+  public void enterChannel(CustomOAuth2User customOAuth2User, Long channelId) {
+    // TODO: 채널의 정원이 가득 찼을 경우, 채널에 참가하지 못하게 하는 로직 필요.
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다.")); // TODO: 예외처리
+
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+
+    if (channel.getChannelParticipants().stream().map(it -> it.getUser().getUserEmail())
+        .noneMatch(it -> it.equals(user.getUserEmail()))) {
+      Participant participant = Participant.viewer(user, channel);
+      channel.getChannelParticipants().add(participant);
+      participantRepository.save(participant);
+      channelRepository.save(channel);
+    } else {
+      throw new RuntimeException("이미 채널에 참여하고 있습니다."); // TODO: 예외처리
+    }
+  }
+
+  @Override
+  @Transactional
+  public void userExitChannel(CustomOAuth2User customOAuth2User, Long channelId) {
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다.")); // TODO: 예외처리
+
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+
+    if (channel.getChannelParticipants().stream().map(it -> it.getUser().getUserEmail())
+        .anyMatch(it -> it.equals(user.getUserEmail()))) {
+      participantRepository.deleteByUser(user);
+    } else {
+      throw new RuntimeException("해당 채널에 참여하고 있지 않습니다."); // TODO: 예외처리
+    }
+  } // TODO: 테스트코드를 활용해 테스트 필요.
+
+  @Override
+  @Transactional
+  public void hostExitChannel(CustomOAuth2User customOAuth2User, Long channelId) {
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다.")); // TODO: 예외처리
+
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+
+    if (channel.getChannelParticipants().stream().filter(it -> it.getIsHost().equals(true))
+        .anyMatch(it -> it.getUser().getUserEmail().equals(user.getUserEmail()))) {
+      participantRepository.deleteByChannel(channel);
+      Channel.closeChannel(channel);
+      channelRepository.save(channel);
+    } else {
+      throw new RuntimeException("호스트가 아닌 사용자는 채널을 닫을 수 없습니다."); // TODO: 예외처리
+    }
+  }
+
+  @Override
+  @Transactional
+  public ChannelResponse addVideoToChannel(Long channelId, VideoRequest videoRequest,
+      CustomOAuth2User customOAuth2User) {
+    //1. 로그인 한 유저 정보 가져오기.
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 채널 Id를 통해 해당 채널 검색.
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다.")); // TODO: 예외처리
+    //3. 유저가 해당 채널의 참여자인지 검증.
+    if (channel.getChannelParticipants().stream().noneMatch(it -> it.getUser().equals(user))) {
+      throw new RuntimeException("해당 채널에 참여중이지 않습니다."); // TODO: 예외처리
+    }
+    //4. 해당 채널 플레이리스트 가져오기.
+    Playlist playlist = channel.getChannelPlaylist();
+    //5. 비디오 추가.
+    Video video = Video.createVideo(videoRequest, playlist.getVideoList());
+    playlist.getVideoList().add(video);
+    playlistRepository.save(playlist);
+    channelRepository.save(channel);
+    //6. 채널response로 반환.
+    PlaylistResponse playlistResponse = PlaylistResponse.from(playlist);
+    List<ParticipantResponse> participantResponseList = channel.getChannelParticipants().stream()
+        .map(
+            ParticipantResponse::createParticipantResponse).toList();
+    return ChannelResponse.createChannelResponse(channel, playlistResponse,
+        participantResponseList);
+  }
+
+  @Override
+  @Transactional
+  public ChannelResponse deleteVideoToChannel(Long channelId, Long id,
+      CustomOAuth2User customOAuth2User) {
+    //1. 로그인한 유저 정보 가져오기.
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 채널 ID를 통해 채널 가져오기.
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다.")); // TODO: 예외처리
+    //3. 유저가 해당 채널의 Host인지 검증.
+    if (channel.getChannelParticipants().stream().filter(it -> it.getIsHost().equals(true))
+        .noneMatch(it -> it.getUser().equals(user))) {
+      throw new RuntimeException("해당 채널의 호스트가 아닙니다."); // TODO: 예외처리
+    }
+    //4. 해당 채널 플레이리스트 가져오기.
+    Playlist playlist = channel.getChannelPlaylist();
+    //4-1. 플레이리스트에서 비디오 리스트 가져오기
+    List<Video> videoList = playlist.getVideoList();
+    //5. 플레이리스트의 video 중 id값이 같은 것 제거.
+    Video video = videoList.stream().filter(it -> it.getId().equals(id)).findFirst()
+        .orElseThrow(() -> new RuntimeException("해당하는 비디오가 없습니다."));
+    videoList.remove(video);
+    playlistRepository.save(playlist);
+    channelRepository.save(channel);
+    //6. 채널 response로 반환
+    PlaylistResponse playlistResponse = PlaylistResponse.from(playlist);
+    List<ParticipantResponse> participantResponseList = channel.getChannelParticipants().stream()
+        .map(
+            ParticipantResponse::createParticipantResponse).toList();
+    return ChannelResponse.createChannelResponse(channel, playlistResponse,
+        participantResponseList);
+  }
+
+  @Override
+  @Transactional
+  public UserPlaylistResponse savePlaylistToUserPlaylist(Long channelId, CustomOAuth2User customOAuth2User) {
+    //1. 로그인 한 유저 정보를 가져온다.
+    User user = userRepository.findByUserEmail(customOAuth2User.findEmail());
+    //2. 채널 ID를 통해 채널을 가져온다.
+    Channel channel = channelRepository.findById(channelId)
+        .orElseThrow(() -> new RuntimeException("해당 채널이 없습니다."));// TODO: 예외처리
+    //3. 채널의 플레이리스트 정보를 가져온다.
+    Playlist playlist = channel.getChannelPlaylist();
+    //4. 유저플레이리스트를 생성한다. 생성 시, 유저플레이리스트네임은 Playlist_uuid 값으로 저장한다.(추후 변경)
+    UserPlaylist userPlaylist = UserPlaylist.fromChannelPlaylist(user, playlist);
+    //5. 유저 플레이리스트를 저장한다.
+    userPlaylistRepository.save(userPlaylist);
+    //6. userPlaylistResponse로 반환
+    return UserPlaylistResponse.from(userPlaylist);
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/type/ChannelStatus.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/type/ChannelStatus.java
@@ -1,0 +1,6 @@
+package com.zerobase.plistbackend.module.channel.type;
+
+public enum ChannelStatus {
+  CHANNEL_STATUS_ACTIVE,
+  CHANNEL_STATUS_CLOSED
+}

--- a/src/main/java/com/zerobase/plistbackend/module/participant/entity/Participant.java
+++ b/src/main/java/com/zerobase/plistbackend/module/participant/entity/Participant.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,12 +19,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @Table(name = "participant")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant {
 
@@ -46,6 +49,22 @@ public class Participant {
   @CreatedDate
   @Column(name = "participant_created_at")
   private Timestamp participantCreatedAt;
+
+  public static Participant host(User user, Channel channel) {
+    return Participant.builder()
+        .user(user)
+        .channel(channel)
+        .isHost(true)
+        .build();
+  }
+
+  public static Participant viewer(User user, Channel channel) {
+    return Participant.builder()
+        .user(user)
+        .channel(channel)
+        .isHost(false)
+        .build();
+  }
 
   public Boolean getHostStatus() {
     return isHost;

--- a/src/main/java/com/zerobase/plistbackend/module/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/participant/repository/ParticipantRepository.java
@@ -1,0 +1,16 @@
+package com.zerobase.plistbackend.module.participant.repository;
+
+import com.zerobase.plistbackend.module.channel.entity.Channel;
+import com.zerobase.plistbackend.module.participant.entity.Participant;
+import com.zerobase.plistbackend.module.user.entity.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+  void deleteByUser(User user);
+
+  void deleteByChannel(Channel channel);
+
+  List<Participant> findByUser(User user);
+}

--- a/src/main/java/com/zerobase/plistbackend/module/playlist/dto/response/PlaylistResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/playlist/dto/response/PlaylistResponse.java
@@ -1,0 +1,28 @@
+package com.zerobase.plistbackend.module.playlist.dto.response;
+
+import com.zerobase.plistbackend.module.playlist.entity.Playlist;
+import com.zerobase.plistbackend.module.userplaylist.model.Video;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaylistResponse {
+
+  private Long playlistId;
+  private List<Video> videoList;
+
+  public static PlaylistResponse from(Playlist playlist) {
+    return PlaylistResponse.builder()
+        .playlistId(playlist.getPlaylistId())
+        .videoList(playlist.getVideoList())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/playlist/entity/Playlist.java
+++ b/src/main/java/com/zerobase/plistbackend/module/playlist/entity/Playlist.java
@@ -2,30 +2,32 @@ package com.zerobase.plistbackend.module.playlist.entity;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.playlist.util.PlaylistVideoConverter;
+import com.zerobase.plistbackend.module.userplaylist.entity.UserPlaylist;
 import com.zerobase.plistbackend.module.userplaylist.model.Video;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @Table(name = "playlist")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Playlist {
 
   @Id
@@ -33,12 +35,18 @@ public class Playlist {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long playlistId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @OneToOne
   @JoinColumn(name = "channel_id")
   private Channel channel;
 
   @Lob
-  @Column(name = "video")
+  @Column(name = "video", columnDefinition = "LONGTEXT")
   @Convert(converter = PlaylistVideoConverter.class)
-  private Video video;
+  private List<Video> videoList;
+
+  public static Playlist from(UserPlaylist userPlaylist) {
+    return Playlist.builder()
+        .videoList(userPlaylist.getVideoList())
+        .build();
+  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.plistbackend.module.playlist.repository;
+
+import com.zerobase.plistbackend.module.playlist.entity.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+}

--- a/src/main/java/com/zerobase/plistbackend/module/playlist/util/PlaylistVideoConverter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/playlist/util/PlaylistVideoConverter.java
@@ -5,16 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.plistbackend.module.userplaylist.model.Video;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Converter
 @RequiredArgsConstructor
-public class PlaylistVideoConverter implements AttributeConverter<Video, String> {
+public class PlaylistVideoConverter implements AttributeConverter<List<Video>, String> {
 
   private final ObjectMapper mapper;
 
   @Override
-  public String convertToDatabaseColumn(Video video) {
+  public String convertToDatabaseColumn(List<Video> video) {
     try {
       return mapper.writeValueAsString(video);
     } catch (JsonProcessingException e) {
@@ -23,9 +24,10 @@ public class PlaylistVideoConverter implements AttributeConverter<Video, String>
   }
 
   @Override
-  public Video convertToEntityAttribute(String json) {
+  public List<Video> convertToEntityAttribute(String json) {
     try {
-      return mapper.readValue(json, Video.class);
+      return mapper.readValue(json,
+          mapper.getTypeFactory().constructCollectionType(List.class, Video.class));
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Error converting JSON to Video", e);
     }

--- a/src/main/java/com/zerobase/plistbackend/module/user/entity/User.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/entity/User.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.participant.entity.Participant;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -12,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,12 +21,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @Table(name = "user")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
@@ -38,7 +40,7 @@ public class User {
   @Column(name = "user_email")
   private String userEmail;
 
-  @Column(name = "user_name", nullable = false)
+  @Column(name = "user_name", length = 30, nullable = false)
   private String userName;
 
   @CreatedDate
@@ -57,6 +59,6 @@ public class User {
   private String userImage;
 
   @OneToMany(mappedBy = "user")
-  private List<Participant> participants = new ArrayList<>();
+  private List<Participant> participants;
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 채널 기능 부재
**TO-BE**
- 채널 기능 추가
  - 채널 생성
    - 채널을 생성하는 호스트가 이미 채널을 생성 중이라면 에러 반환, 채널 요청 값에 따라 채널 생성, 채널 생성 후 채널의 참가자로 호스트 추가
  - 현재 스트리밍 중인 채널 전체 목록 검색
  - 현재 스트리밍 중인 채널 이름으로 검색
  - 현재 스트리밍 중인 채널 카테고리명으로 검색
  - 사용자 채널 입장 ( 테스트 필요 )
    - 현재 채널의 정원이 가득찼을 경우, 채널에 입장을 막는 로직이 없음 (추가 예정)
    - 해당 채널에 참여하고 있는지만 검증하고 있음.
  - 사용자 채널 퇴장 ( 테스트 필요 )
    - 해당 채널에 참여하고 있는지 검증 후 퇴장
  - 호스트 채널 퇴장
    - 채널상태를 Closed 상태로 변경하고, 참가자 모두를 삭제
  - 채널 영상 추가
    - 현재 채널의 플레이리스트에 Video 추가
  - 채널 영상 삭제
    - 현재 채널의 플레이리스트에 Video 삭제
  - 채널 퇴장 시, 채널 플레이리스트를 유저플레이리스트로 저장
    - 추가하기를 눌렀을 시 실행
    - 현재 채널의 플레이리스트를 가져와 유저플레이리스트로 저장
    - 생성되는 유저플레이리스트 제목은 Playlist_UUID 로 생성 -> 추후 변경 예정
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
  - PostMan을 활용한 API 테스트 완료 -> 응답값으로 확인

**TO-DO**
  - 채널 플레이리스트 영상 순서 변경
  - 채널ID 값으로 채널 검색
  - 채널이름&호스트이름&카테고리로 검색
  - 채널 플레이리스트 조회
  - 요청값 길이 제한
  - 현재 TimeStamp 응답값이 밀리초로 나오는 데, 날짜시간으로 변경
