### PR TITLE
Feature/user refresh

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/refresh/controller/RefreshController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/controller/RefreshController.java
@@ -1,0 +1,25 @@
+package com.zerobase.plistbackend.module.refresh.controller;
+
+import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
+import com.zerobase.plistbackend.module.refresh.service.RefreshService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v3/api")
+@Tag(name = "Jwt Token API", description = "Access token 관리")
+public class RefreshController {
+
+  private final RefreshService refreshService;
+
+  @PostMapping("/auth/access")
+  public ResponseEntity<NewAccessResponse> newAccess(HttpServletRequest request) {
+    return ResponseEntity.status(201).body(refreshService.newAccessToken(request));
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/dto/NewAccessResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/dto/NewAccessResponse.java
@@ -1,0 +1,5 @@
+package com.zerobase.plistbackend.module.refresh.dto;
+
+public record NewAccessResponse(String accessToken) {
+
+}

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/entity/Refresh.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/entity/Refresh.java
@@ -39,4 +39,9 @@ public class Refresh {
 
   @Column(name = "refresh_expiration")
   private Timestamp refreshExpiration;
+
+  public void updateRefreshToken(String refreshToken, Timestamp expirationTime) {
+    this.refreshToken = refreshToken;
+    this.refreshExpiration = expirationTime;
+  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
@@ -1,0 +1,16 @@
+package com.zerobase.plistbackend.module.refresh.repository;
+
+import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<Refresh, Long> {
+
+  Optional<Refresh> findByUser_UserEmail(String email);
+
+  Optional<Refresh> findByRefreshToken(String token);
+
+  @Transactional
+  void deleteByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshService.java
@@ -1,0 +1,89 @@
+package com.zerobase.plistbackend.module.refresh.service;
+
+import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
+import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class RefreshService {
+
+  private final Long refreshExpired;
+  private final RefreshRepository refreshRepository;
+  private final UserRepository userRepository;
+  private final JwtUtil jwtUtil;
+
+  public RefreshService(@Value("${jwt.refresh}") Long refreshExpired,
+      RefreshRepository refreshRepository,
+      JwtUtil jwtUtil,
+      UserRepository userRepository) {
+    this.refreshExpired = refreshExpired;
+    this.refreshRepository = refreshRepository;
+    this.jwtUtil = jwtUtil;
+    this.userRepository = userRepository;
+  }
+
+  @Transactional
+  public void addRefreshEntity(String email, String token, Timestamp expired) {
+
+    Optional<Refresh> existingRefresh = refreshRepository.findByUser_UserEmail(email);
+
+    if (existingRefresh.isPresent()) {
+      Refresh refresh = existingRefresh.get();
+      refresh.updateRefreshToken(token, expired);
+      log.info("Updated Refresh token: {}", refresh.getRefreshToken());
+    } else {
+      Refresh refresh = Refresh.builder()
+          .user(userRepository.findByUserEmail(email))
+          .refreshToken(token)
+          .refreshExpiration(expired)
+          .build();
+      refreshRepository.save(refresh);
+      log.info("Created new Refresh token: {}", refresh.getRefreshToken());
+    }
+  }
+
+  public void checkRefresh(String refreshToken) {
+
+    log.info("Check refresh token: {}", refreshToken);
+
+    // refresh 토큰이 없는 경우
+    if (refreshToken == null) {
+      log.error("refresh token null");
+    }
+
+    // refresh 토큰이 만료가 된 경우
+    try {
+      jwtUtil.isExpired(refreshToken);
+    } catch (ExpiredJwtException e) {
+      log.error("refresh token expired");
+    }
+
+    // 토큰이 refresh 인지 확인
+    String category = jwtUtil.findCategory(refreshToken);
+    if (!category.equals("refresh")) {
+      log.error("refresh token invalid");
+    }
+  }
+
+  public NewAccessResponse newAccessToken(HttpServletRequest request) {
+    String refreshToken = jwtUtil.findToken(request, "refresh");
+    checkRefresh(refreshToken);
+
+    String email = jwtUtil.findEmail(refreshToken);
+    String role = jwtUtil.findRole(refreshToken);
+
+    return new NewAccessResponse(jwtUtil.createJwt("access", email, role));
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
@@ -1,9 +1,15 @@
 package com.zerobase.plistbackend.module.user.config;
 
+import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
+import com.zerobase.plistbackend.module.refresh.service.RefreshService;
+import com.zerobase.plistbackend.module.user.jwt.CustomLogoutFilter;
 import com.zerobase.plistbackend.module.user.jwt.JwtFilter;
 import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
 import com.zerobase.plistbackend.module.user.oauth2.CustomSuccessHandler;
 import com.zerobase.plistbackend.module.user.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +17,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
 @EnableWebSecurity
@@ -22,24 +30,36 @@ public class SecurityConfig {
   private final CustomOAuth2UserService customOAuth2UserService;
   private final CustomSuccessHandler customSuccessHandler;
   private final JwtUtil jwtUtil;
+  private final RefreshRepository refreshRepository;
+
+  private static final String[] PUBLIC_URLS = {
+      "/v3/api/",
+      "/oauth2/**",
+      "/auth/access",
+      "/"
+  };
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    // csrf disable
-    http
-        .csrf(AbstractHttpConfigurer::disable);
 
-    // Form 로그인 방식 disable
     http
-        .formLogin(AbstractHttpConfigurer::disable);
+        .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
+          CorsConfiguration configuration = new CorsConfiguration();
+          configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+          configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+          configuration.setAllowCredentials(true);  // 쿠키 전송 허용
+          configuration.setAllowedHeaders(Collections.singletonList("*"));
+          configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+//          configuration.setMaxAge(3600L);
+          return configuration;
+          }));
 
-    // HTTP Basic 인증 방식 disable
+    http.cors(AbstractHttpConfigurer::disable);
+
     http
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable);
-
-    // JwtFilter 추가
-    http
-        .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
     // oauth2
     http
@@ -51,13 +71,24 @@ public class SecurityConfig {
                 .successHandler(customSuccessHandler)
         );
 
-
     // 경로별 인가 작업
     http
         .authorizeHttpRequests((auth) -> auth
-            .requestMatchers("/", "/login", "/oauth2/**").permitAll()
-            .anyRequest().permitAll());
-//            .anyRequest().authenticated());
+            .requestMatchers(PUBLIC_URLS).permitAll()
+            .anyRequest().authenticated());
+
+    // 인증되지 않은 사용자에게 401 Unauthorized 반환
+    http
+        .exceptionHandling((exception) ->
+            exception.authenticationEntryPoint((request, response, authException) ->
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")));
+
+    // JwtFilter 추가
+    http
+        .addFilterAfter(new JwtFilter(jwtUtil), OAuth2LoginAuthenticationFilter.class);
+
+    http
+        .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
 
     // 세션 설정 : STATELESS
     http

--- a/src/main/java/com/zerobase/plistbackend/module/user/entity/User.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/entity/User.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.participant.entity.Participant;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -21,12 +22,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @Table(name = "user")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 

--- a/src/main/java/com/zerobase/plistbackend/module/user/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/jwt/CustomLogoutFilter.java
@@ -1,0 +1,97 @@
+package com.zerobase.plistbackend.module.user.jwt;
+
+import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+  private final JwtUtil jwtUtil;
+  private final RefreshRepository refreshRepository;
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response,
+      FilterChain chain) throws IOException, ServletException {
+
+    doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+  }
+
+  @Transactional
+  protected void doFilter(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain)
+      throws IOException, ServletException {
+
+    String requestUri = request.getRequestURI();
+    if (!requestUri.matches("^\\/logout$")) {
+
+      chain.doFilter(request, response);
+      return;
+    }
+    String requestMethod = request.getMethod();
+    if (!requestMethod.equals("POST")) {
+
+      chain.doFilter(request, response);
+      return;
+    }
+
+    //get refresh token
+    String refresh = jwtUtil.findToken(request, "refresh");
+
+    //refresh null check
+    if (refresh == null) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    //expired check
+    try {
+      jwtUtil.isExpired(refresh);
+    } catch (ExpiredJwtException e) {
+      //response status code
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+    String category = jwtUtil.findCategory(refresh);
+    if (!category.equals("refresh")) {
+      //response status code
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    //DB에 저장되어 있는지 확인
+    Optional<Refresh> refreshEntity = refreshRepository.findByRefreshToken(refresh);
+
+    if (refreshEntity.isEmpty()) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    //로그아웃 진행
+    //Refresh 토큰 DB에서 제거
+    refreshRepository.deleteByRefreshToken(refresh);
+
+    //Refresh 토큰 Cookie 값 0
+    Cookie cookie = new Cookie("refresh", null);
+    cookie.setMaxAge(0);
+    cookie.setPath("/");
+
+    response.addCookie(cookie);
+    response.setStatus(HttpServletResponse.SC_OK);
+  }
+}
+

--- a/src/main/java/com/zerobase/plistbackend/module/user/jwt/JwtUtil.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/jwt/JwtUtil.java
@@ -1,42 +1,107 @@
 package com.zerobase.plistbackend.module.user.jwt;
 
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class JwtUtil {
 
   private final SecretKey secretKey;
+  private final Long accessExpired;
+  private final Long refreshExpired;
+  private final UserRepository userRepository;
 
-  public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
-    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIG.HS256.key().build().getAlgorithm());
+  public JwtUtil(
+      @Value("${spring.jwt.secret}") String secret,
+      @Value("${jwt.access}") Long accessExpired,
+      @Value("${jwt.refresh}") Long refreshExpired,
+      UserRepository userRepository) {
+    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+        SIG.HS256.key().build().getAlgorithm());
+    this.accessExpired = accessExpired;
+    this.refreshExpired = refreshExpired;
+    this.userRepository = userRepository;
   }
 
-  public String createJwt(String email, String role, Long expiredMs) {
+  @Transactional(readOnly = true)
+  public String createJwt(String category, String email, String role) {
+    Date expiration = new Date(System.currentTimeMillis() + findExpired(category));
+
     return Jwts.builder()
+        .claim("category", category)
         .claim("email", email)
         .claim("role", role)
+        .claim("id", userRepository.findByUserEmail(email).getUserId())
+        .claim("expired", expiration)
         .issuedAt(new Date(System.currentTimeMillis()))
-        .expiration(new Date(System.currentTimeMillis() + expiredMs))
+        .expiration(expiration)
         .signWith(secretKey)
         .compact();
   }
 
-  public String findEmail (String token) {
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+  private Long findExpired(String category) {
+    if (category.equals("access")) {
+      return accessExpired;
+    } else if (category.equals("refresh")) {
+      return refreshExpired;
+    }
+    return null;
   }
 
-  public String findRole (String token) {
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+  public String findCategory(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("category", String.class);
   }
 
-  public Boolean isExpired (String token) {
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+  public String findEmail(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("email", String.class);
+  }
+
+  public String findRole(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("role", String.class);
+  }
+
+  public Boolean isExpired(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .getExpiration().before(new Date());
+  }
+
+  public Timestamp findExpiration(String token) {
+    Date expired = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("expired", Date.class);
+    return new Timestamp(expired.getTime());
+  }
+
+  public String findToken(HttpServletRequest request, String category) {
+    Cookie[] cookies = request.getCookies();
+    for (Cookie cookie : cookies) {
+      if (cookie.getName().equals(category)) {
+        return cookie.getValue();
+      }
+    }
+    return null;
+  }
+
+
+  public Cookie createCookie(String key, String value) {
+    Cookie cookie = new Cookie(key, value);
+    cookie.setMaxAge(findExpired(key).intValue() / 1000);
+    cookie.setPath("/");
+    cookie.setSecure(true);
+    cookie.setHttpOnly(true);
+    return cookie;
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/model/auth/CustomOAuth2User.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/model/auth/CustomOAuth2User.java
@@ -39,4 +39,12 @@ public class CustomOAuth2User implements OAuth2User {
     return userDetail.getEmail();
   }
 
+  public Boolean findIsMember() {
+    return userDetail.getIsMember();
+  }
+
+  public Long findId() {
+    return userDetail.getId();
+  }
+
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/model/auth/UserDetail.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/model/auth/UserDetail.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @Builder
 public class UserDetail {
 
+  private Long id;
   private String role;
   private String name;
   private String email;
+  private Boolean isMember;
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/oauth2/CustomSuccessHandler.java
@@ -1,12 +1,12 @@
 package com.zerobase.plistbackend.module.user.oauth2;
 
+import com.zerobase.plistbackend.module.refresh.service.RefreshService;
 import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Iterator;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +19,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-  private final Long EXPIRES_IN_MS = 600000L;
-
   private final JwtUtil jwtUtil;
+  private final RefreshService refreshService;
 
   @Override
-  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
 
     CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-
     String email = customOAuth2User.findEmail();
 
     Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -35,17 +34,17 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     GrantedAuthority auth = iterator.next();
     String role = auth.getAuthority();
 
-    String token = jwtUtil.createJwt(email, role, EXPIRES_IN_MS);
+    String access = jwtUtil.createJwt("access", email, role);
+    String refresh = jwtUtil.createJwt("refresh", email, role);
+    Timestamp expired = jwtUtil.findExpiration(refresh);
+    refreshService.addRefreshEntity(email, refresh, expired);
 
-    response.addCookie(createCookie("Authorization", token));
-    response.sendRedirect(request.getContextPath() + "/"); // 추후 변경
+    response.setStatus(302);
+    response.addCookie(jwtUtil.createCookie("refresh", refresh));
+    String url = String.format("http://localhost:8080/?access-token=%s&is-member=%s",
+        access, customOAuth2User.findIsMember());
+    response.sendRedirect(url);
   }
 
-  private Cookie createCookie(String key, String value) {
-    Cookie cookie = new Cookie(key, value);
-    cookie.setMaxAge(EXPIRES_IN_MS.intValue() / 1000);
-    cookie.setPath("/");
-    cookie.setHttpOnly(true);
-    return cookie;
-  }
+
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/CustomOAuth2UserService.java
@@ -28,13 +28,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
     OAuth2User oAuth2User = super.loadUser(userRequest);
-    OAuth2Response oAuth2Response = RegistrationId.fromId(userRequest.getClientRegistration().getRegistrationId(), oAuth2User);
+    OAuth2Response oAuth2Response = RegistrationId.fromId(
+        userRequest.getClientRegistration().getRegistrationId(), oAuth2User);
 
     String email = oAuth2Response.findEmail();
     log.info("Request Login email: {}", email);
     User existData = userRepository.findByUserEmail(email);
+    Boolean isMember = true;
 
-    if(existData == null) {
+    if (existData == null) {
+      isMember = false;
       existData = User.builder()
           .userEmail(email)
           .userName(oAuth2Response.findName())
@@ -47,7 +50,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     UserDetail userDetail = UserDetail.builder()
         .name(existData.getUserName())
         .email(existData.getUserEmail())
-        .role(String.valueOf(existData.getUserRole())).build();
+        .role(String.valueOf(existData.getUserRole()))
+        .isMember(isMember).build();
 
     return new CustomOAuth2User(userDetail);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,13 @@ spring:
   jwt:
     secret: ${jwt_secret}
 
+# 시간 설정 (개발중에는 access 1일로 임시 지정)
+# Access Token: 30 min
+# Refresh Token: 7 days
+jwt:
+  access: 68400000
+  refresh: 478800000
+
 youtube-api:
   url: "https://www.googleapis.com/youtube/v3/search?key=%s&q=%s&type=%s&part=%s&maxResults=%d&order=%s&relevanceLanguage=%s&videoEmbeddable=%s"
   type: "video" # 검색할 타입


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인 응답값 쿠키에 저장됨
- Refresh 기능 부재
- cors 요청 설정

**TO-BE**
- 시간 설정 변경
  - access token : 30분(개발기간에는 1일), refresh token : 7일

- 인증한 유저 정보 추가
  - isMember, id 값 추가

- 로그인시 토큰 반환 방법 변경
  - http://localhost:8080/?access-token=%s&is-member=%s 으로 헤더에 access, 신규 유저 확인값으로 다이렉트
  - 쿠키에는 refresh 값 담아 저장

- Refresh 발급 및 access token 재발급
  - refresh token 생성
  - refresh token 검증 로직 구현
  - refresh 응답으로 쿠키에 저장
  - access token 만료시 refresh 확인 후 재발급 기능 추가

- security 설정 추가
  - cors 3000 포트 연결
  - logout 필터 추가
  - 로그인 에러 응답 설정

- 저장시 자동으로 값 입력 설정

- 로그아웃 요청 필터 추가
  1. 로그아웃 요청 경로 확인
  2. Refresh 토큰 값 유무 확인
  3. Refresh 토큰 값에서 카테고리 확인
  4. DB 에 저장되어 있는지 확인
  5. 모든 검증이 된 경우 DB, 쿠키 값 제거

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
테스트 코드는 아직 미흡한 관계로 공부한 후 올리도록 하겠습니다!
API 테스트는 아래와 같이 수행하였습니다.
1. http://localhost:8080/login/oauth2/code/google 요청
access-token=JWT&is-member=true, 쿠키 refresh 값 저장 확인
2. http://localhost:3000/login/oauth2/code/google 요청 -> 위와 같이 반환됨
3. http://localhost:8080/auth/access 요청 -> “code”: 201, accessToken: JWT 
4. http://localhost:8080/auth/logout -> Refresh 토큰 삭제

아직 에러 처리 부분은 미구현입니다
다음 PR 에 같이 추가해서 올리겠습니다!