### PR TITLE
refactor/sendMessage

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/websocket/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/dto/request/ChatMessageRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageRequest {
-  private String sender;
+  private String email;
   private String message;
-
 }

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/dto/request/VideoSyncRequest.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/dto/request/VideoSyncRequest.java
@@ -1,10 +1,14 @@
 package com.zerobase.plistbackend.module.websocket.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VideoSyncRequest {
   private String videoId;
   private Long currentTime;

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/dto/response/ChatMessageResponse.java
@@ -1,5 +1,6 @@
 package com.zerobase.plistbackend.module.websocket.dto.response;
 
+import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,11 +16,11 @@ public class ChatMessageResponse {
   private String message;
   private String userProfileImg;
 
-  public static ChatMessageResponse from(ChatMessageRequest request, String userProfileImg) {
+  public static ChatMessageResponse from(ChatMessageRequest request,User findUser) {
     return ChatMessageResponse.builder()
-        .sender(request.getSender())
+        .sender(findUser.getUserName())
         .message(request.getMessage())
-        .userProfileImg(userProfileImg)
+        .userProfileImg(findUser.getUserImage())
         .build();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/dto/response/VideoSyncResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/dto/response/VideoSyncResponse.java
@@ -1,13 +1,19 @@
 package com.zerobase.plistbackend.module.websocket.dto.response;
 
 import com.zerobase.plistbackend.module.websocket.dto.request.VideoSyncRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VideoSyncResponse {
-  private final String videoId;
-  private final Long playStates;
-  private final Long currentTime;
+  private String videoId;
+  private Long playStates;
+  private Long currentTime;
 
   public VideoSyncResponse(VideoSyncRequest request) {
     this.videoId = request.getVideoId();

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
@@ -6,10 +6,8 @@ import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
 import com.zerobase.plistbackend.module.channel.type.ChannelErrorStatus;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.entity.User;
-import com.zerobase.plistbackend.module.user.exception.OAuth2UserException;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.user.repository.UserRepository;
-import com.zerobase.plistbackend.module.user.type.OAuth2UserErrorStatus;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
 import com.zerobase.plistbackend.module.websocket.dto.response.ChatMessageResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +24,8 @@ public class WebSocketServiceImpl implements WebSocketService {
 
   @Override
   public ChatMessageResponse sendMessage(ChatMessageRequest request) {
-    User findUser = userRepository.findByUserName(request.getSender())
-        .orElseThrow(() -> new OAuth2UserException(OAuth2UserErrorStatus.NOT_FOUND));
-    return ChatMessageResponse.from(request, findUser.getUserImage());
+    User findUser = userRepository.findByUserEmail(request.getEmail());
+    return ChatMessageResponse.from(request,findUser);
   }
 
   @Override
@@ -38,8 +35,7 @@ public class WebSocketServiceImpl implements WebSocketService {
             ChannelStatus.CHANNEL_STATUS_ACTIVE)
         .orElseThrow(() -> new ChannelException(ChannelErrorStatus.NOT_FOUND));
 
-    User findUser = userRepository.findByUserName(user.getName())
-        .orElseThrow(() -> new OAuth2UserException(OAuth2UserErrorStatus.NOT_FOUND));
+    User findUser = userRepository.findByUserEmail(user.findEmail());
 
     return findChannel.getChannelHostId().equals(findUser.getUserId());
   }

--- a/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.plistbackend.common.app.exception.ErrorResponse;
+import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.websocket.domain.VideoSyncManager;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
@@ -38,13 +39,18 @@ class WebSocketControllerTest {
   @DisplayName("채팅 메시지를 보낼 수 있다")
   void testSendMessage() {
     //given
+    User user = User.builder()
+        .userName("user")
+        .userEmail("test@test.com")
+        .userImage("userimg.img")
+        .build();
     ChatMessageRequest request = ChatMessageRequest.builder()
-        .sender("TestMember1")
+        .email(user.getUserEmail())
         .message("안녕하세요")
         .build();
 
     ChatMessageResponse response = ChatMessageResponse
-        .from(request, "testImg.testImg");
+        .from(request, user);
 
     //when
     when(webSocketService.sendMessage(request)).thenReturn(response);
@@ -52,7 +58,7 @@ class WebSocketControllerTest {
 
     //then
     assertThat(response).isEqualTo(messageResponse);
-    assertThat(response.getSender()).isEqualTo("TestMember1");
+    assertThat(response.getSender()).isEqualTo("user");
     assertThat(response.getMessage()).isEqualTo("안녕하세요");
   }
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- sendMessage 호출 시 username으로 해당 user를 찾아오는데 username 중복시 DB에서 조회를 못해오는 이슈 존재

- 클라이언트에서 데이터가 들어올 때 JSON 직렬화 및 역직렬화시 기본 생성자 부재로 인한 이슈 존재

**TO-BE**

- username으로 조회하는게 아닌 userEmail로 조회해 올 수있도록 로직 변경
- 기본 생성자를 가질 수 있도록 @NoArgsConstructor 애노테이션 사용 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
