### PR TITLE
refactor/isHost-query

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -110,4 +110,9 @@ public class Channel {
     participant.getUser().setParticipant(null);
     participant.setUser(null);
   }
+
+  public boolean getHost() {
+    return getChannelParticipants().stream()
+        .anyMatch(Participant::getIsHost);
+  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -46,8 +46,12 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
   List<Channel> findByChannelHostIdAndChannelStatus(Long userId, ChannelStatus channelStatus);
 
-  Optional<Channel> findByChannelIdAndChannelStatus(Long channelId,
-      ChannelStatus channelStatusActive);
+  @Query("SELECT c FROM Channel c " +
+      "LEFT JOIN FETCH c.channelPlaylist p " +
+      "LEFT JOIN FETCH c.channelParticipants cp " +
+      "WHERE c.channelId = :channelId AND c.channelStatus = :channelStatus")
+  Optional<Channel> findByChannelIdAndChannelStatus(@Param("channelId") Long channelId,
+      @Param("channelStatus") ChannelStatus channelStatus);
 
   Optional<Channel> findByChannelIdAndChannelHostId(Long channelId, Long userId);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketController.java
@@ -77,6 +77,7 @@ public class WebSocketController {
       description = "WebSocket 연결을 통해 메시지를 전송합니다. REST 호출은 지원하지 않습니다."
           + "-> 클라이언트가 데이터를 서버로 전송할 주소 /video.control.{channelId}, 서버를 거치고 처리한 결과를 전송할 주소 /sub/video.{channelId}"
   )
+  @PostMapping("/video.control.{channelId}")
   @MessageMapping("/video.control.{channelId}")
   @SendTo("/sub/video.{channelId}")
   public VideoSyncResponse controlVideo(@DestinationVariable Long channelId,

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketController.java
@@ -1,7 +1,6 @@
 package com.zerobase.plistbackend.module.websocket.controller;
 
 import com.zerobase.plistbackend.module.channel.type.ChannelErrorStatus;
-import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.websocket.domain.VideoSyncManager;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
 import com.zerobase.plistbackend.module.websocket.dto.request.VideoSyncRequest;
@@ -17,7 +16,6 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -81,9 +79,9 @@ public class WebSocketController {
   @MessageMapping("/video.control.{channelId}")
   @SendTo("/sub/video.{channelId}")
   public VideoSyncResponse controlVideo(@DestinationVariable Long channelId,
-      @Payload VideoSyncRequest request, @AuthenticationPrincipal CustomOAuth2User user) {
+      @Payload VideoSyncRequest request) {
 
-    if (!webSocketService.isHost(channelId, user)) {
+    if (!webSocketService.isHost(channelId)) {
       throw new WebSocketControllerException(ChannelErrorStatus.NOT_HOST);
     }
     videoSyncManager.updateCurrentTime(channelId, request.getCurrentTime());

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketService.java
@@ -1,6 +1,5 @@
 package com.zerobase.plistbackend.module.websocket.service;
 
-import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
 import com.zerobase.plistbackend.module.websocket.dto.response.ChatMessageResponse;
 
@@ -8,5 +7,5 @@ public interface WebSocketService {
 
   ChatMessageResponse sendMessage(ChatMessageRequest request);
 
-  boolean isHost(Long channelId, CustomOAuth2User user);
+  boolean isHost(Long channelId);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
@@ -7,7 +7,6 @@ import com.zerobase.plistbackend.module.channel.type.ChannelErrorStatus;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.exception.OAuth2UserException;
-import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import com.zerobase.plistbackend.module.user.type.OAuth2UserErrorStatus;
 import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest;
@@ -32,15 +31,12 @@ public class WebSocketServiceImpl implements WebSocketService {
   }
 
   @Override
-  public boolean isHost(Long channelId, CustomOAuth2User user) {
+  public boolean isHost(Long channelId) {
     // TODO -> 전용 DTO + 네이티브 쿼리로 쿼리 최적화
     Channel findChannel = channelRepository.findByChannelIdAndChannelStatus(channelId,
             ChannelStatus.CHANNEL_STATUS_ACTIVE)
         .orElseThrow(() -> new ChannelException(ChannelErrorStatus.NOT_FOUND));
 
-    User findUser = userRepository.findByUserName(user.getName())
-        .orElseThrow(() -> new OAuth2UserException(OAuth2UserErrorStatus.NOT_FOUND));
-
-    return findChannel.getChannelHostId().equals(findUser.getUserId());
+    return findChannel.getHost();
   }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
@@ -86,11 +86,10 @@ class WebSocketControllerTest {
         .build();
     Long channelId = 1L;
 
-    CustomOAuth2User user = mock(CustomOAuth2User.class);
 
     //when
-    when(webSocketService.isHost(channelId, user)).thenReturn(true);
-    VideoSyncResponse response = webSocketController.controlVideo(channelId, request, user);
+    when(webSocketService.isHost(channelId)).thenReturn(true);
+    VideoSyncResponse response = webSocketController.controlVideo(channelId, request);
 
     //then
     assertThat(response.getCurrentTime()).isEqualTo(response.getCurrentTime());
@@ -110,11 +109,11 @@ class WebSocketControllerTest {
     CustomOAuth2User user = mock(CustomOAuth2User.class);
 
     //when
-    when(webSocketService.isHost(channelId, user)).thenReturn(false);
+    when(webSocketService.isHost(channelId)).thenReturn(false);
 
     //then
     WebSocketControllerException exception = assertThrows(WebSocketControllerException.class, () ->
-        webSocketController.controlVideo(channelId, request, user));
+        webSocketController.controlVideo(channelId, request));
 
     ErrorResponse errorResponse = ErrorResponse.create(exception.getErrorStatus());
     assertThat(errorResponse.getErrorCode()).isEqualTo(exception.getErrorCode());


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 웹소켓에서 host 여부 가져올 때 헤더에 토큰이 안들어오기 때문에 User의 정보를 가져올 수 없었음

- findByChannelIdAndChannelStatus 조회 쿼리가 3방 나가는 문제

**TO-BE**

- findByChannelIdAndChannelStatus JPQL 페치 조인 적용 -> 조회 쿼리 1번 나가게끔 리팩토링

- 웹소켓에서 host여부를 가져올 때 channel에 연관관계로 묶인 participant 테이블에서 host를 찾아올 수있도록 변경

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
