### PR TITLE
feat: SwaggerConfig에 로컬서버와 배포서버 명시

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/common/app/config/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/common/app/config/SwaggerConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,8 +23,18 @@ public class SwaggerConfig {
         .title("PLIST API")
         .description("사람과 음악을 잇다, 플리스트");
 
+    Server localServer = new Server();
+    localServer.setUrl("http://localhost:8080");
+    localServer.setDescription("로컬 서버");
+
+    Server prodServer = new Server();
+    prodServer.setUrl("https://api.plist.shop");
+    prodServer.setDescription("운영 서버");
+
     return new OpenAPI()
         .info(info)
+        .addServersItem(localServer)
+        .addServersItem(prodServer)
         .addSecurityItem(new SecurityRequirement().addList(customSchemeName))
         .components(new Components().addSecuritySchemes(customSchemeName, createAPIKeyScheme()));
   }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- HTTPS로 배포해서 Swagger 사용 시 CORS 에러가 나는 이슈 발생

**TO-BE**

- 로컬 서버와 배포 서버의 URL을 명시함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- 아래 사진과 같이 개발 서버와 배포 서버 URL 선택 확인
- 선택한 서버로 요청이 제대로 가는 부분 확인
- 다만 배포 서버 선택 시 배포 서버의 CORS의 설정으로 인해 로컬 서버에서는 안되는 중
![image](https://github.com/user-attachments/assets/27f6792f-ce4e-4d30-a072-a5e21c0bd061)

- [ ] 테스트 코드
- [ ] API 테스트
