### PR TITLE
Refactor/refresh 토큰 만료 스케쥴러 추가 이전 코드 리팩토링

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/PlistBackendApplication.java
+++ b/src/main/java/com/zerobase/plistbackend/PlistBackendApplication.java
@@ -2,7 +2,9 @@ package com.zerobase.plistbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class PlistBackendApplication {
 

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/controller/RefreshController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/controller/RefreshController.java
@@ -1,7 +1,7 @@
 package com.zerobase.plistbackend.module.refresh.controller;
 
 import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
-import com.zerobase.plistbackend.module.refresh.service.RefreshService;
+import com.zerobase.plistbackend.module.refresh.service.RefreshServiceImpl;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Jwt Token API", description = "Access token 관리")
 public class RefreshController {
 
-  private final RefreshService refreshService;
+  private final RefreshServiceImpl refreshService;
 
   @GetMapping("/auth/access")
   public ResponseEntity<NewAccessResponse> newAccess(HttpServletRequest request) {

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/exception/RefreshException.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/exception/RefreshException.java
@@ -1,0 +1,12 @@
+package com.zerobase.plistbackend.module.refresh.exception;
+
+import com.zerobase.plistbackend.common.app.exception.BaseException;
+import com.zerobase.plistbackend.common.app.exception.ErrorStatus;
+
+public class RefreshException extends BaseException {
+
+  public RefreshException(
+      ErrorStatus errorStatus) {
+    super(errorStatus);
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.plistbackend.module.refresh.repository;
 
 import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import java.sql.Timestamp;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,6 @@ public interface RefreshRepository extends JpaRepository<Refresh, Long> {
   Optional<Refresh> findByRefreshToken(String token);
 
   void deleteByRefreshToken(String refreshToken);
+
+  void deleteByRefreshExpirationBefore(Timestamp expired);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshService.java
@@ -1,89 +1,17 @@
 package com.zerobase.plistbackend.module.refresh.service;
 
 import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
-import com.zerobase.plistbackend.module.refresh.entity.Refresh;
-import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
-import com.zerobase.plistbackend.module.user.entity.User;
-import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
-import com.zerobase.plistbackend.module.user.repository.UserRepository;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
-import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Service
-public class RefreshService {
+public interface RefreshService {
 
-  private final Long refreshExpired;
-  private final RefreshRepository refreshRepository;
-  private final UserRepository userRepository;
-  private final JwtUtil jwtUtil;
+  void addRefreshEntity(String email, String token, Timestamp expired);
 
-  public RefreshService(@Value("${jwt.refresh}") Long refreshExpired,
-      RefreshRepository refreshRepository,
-      JwtUtil jwtUtil,
-      UserRepository userRepository) {
-    this.refreshExpired = refreshExpired;
-    this.refreshRepository = refreshRepository;
-    this.jwtUtil = jwtUtil;
-    this.userRepository = userRepository;
-  }
+  void checkRefresh(String refreshToken);
 
-  @Transactional
-  public void addRefreshEntity(String email, String token, Timestamp expired) {
+  NewAccessResponse newAccessToken(HttpServletRequest request);
 
-    Optional<Refresh> existingRefresh = refreshRepository.findByUser_UserEmail(email);
+  void refreshCleanup();
 
-    if (existingRefresh.isPresent()) {
-      Refresh refresh = existingRefresh.get();
-      refresh.updateRefreshToken(token, expired);
-      log.info("Updated Refresh token: {}", refresh.getRefreshToken());
-    } else {
-      Refresh refresh = Refresh.builder()
-          .user(userRepository.findByUserEmail(email))
-          .refreshToken(token)
-          .refreshExpiration(expired)
-          .build();
-      refreshRepository.save(refresh);
-      log.info("Created new Refresh token: {}", refresh.getRefreshToken());
-    }
-  }
-
-  public void checkRefresh(String refreshToken) {
-
-    log.info("Check refresh token: {}", refreshToken);
-
-    // refresh 토큰이 없는 경우
-    if (refreshToken == null) {
-      log.error("refresh token null");
-    }
-
-    // refresh 토큰이 만료가 된 경우
-    try {
-      jwtUtil.isExpired(refreshToken);
-    } catch (ExpiredJwtException e) {
-      log.error("refresh token expired");
-    }
-
-    // 토큰이 refresh 인지 확인
-    String category = jwtUtil.findCategory(refreshToken);
-    if (!category.equals("refresh")) {
-      log.error("refresh token invalid");
-    }
-  }
-
-  public NewAccessResponse newAccessToken(HttpServletRequest request) {
-    String refreshToken = jwtUtil.findToken(request, "refresh");
-    checkRefresh(refreshToken);
-
-    String email = jwtUtil.findEmail(refreshToken);
-    String role = jwtUtil.findRole(refreshToken);
-
-    return new NewAccessResponse(jwtUtil.createJwt("access", email, role));
-  }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshServiceImpl.java
@@ -1,0 +1,86 @@
+package com.zerobase.plistbackend.module.refresh.service;
+
+import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
+import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import com.zerobase.plistbackend.module.refresh.exception.RefreshException;
+import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
+import com.zerobase.plistbackend.module.refresh.type.RefreshErrorStatus;
+import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshServiceImpl implements RefreshService {
+
+  private final RefreshRepository refreshRepository;
+  private final UserRepository userRepository;
+  private final JwtUtil jwtUtil;
+
+  @Transactional
+  public void addRefreshEntity(String email, String token, Timestamp expired) {
+
+    Optional<Refresh> existingRefresh = refreshRepository.findByUser_UserEmail(email);
+
+    if (existingRefresh.isPresent()) {
+      Refresh refresh = existingRefresh.get();
+      refresh.updateRefreshToken(token, expired);
+      log.info("Updated Refresh token: {}", refresh.getRefreshToken());
+    } else {
+      Refresh refresh = Refresh.builder()
+          .user(userRepository.findByUserEmail(email))
+          .refreshToken(token)
+          .refreshExpiration(expired)
+          .build();
+      refreshRepository.save(refresh);
+      log.info("Created new Refresh token: {}", refresh.getRefreshToken());
+    }
+  }
+
+  public void checkRefresh(String refreshToken) {
+
+    log.info("Check refresh token: {}", refreshToken);
+
+    if (refreshToken == null) {
+      throw new RefreshException(RefreshErrorStatus.REFRESH_NOT_FOUND);
+    }
+
+    try {
+      jwtUtil.isExpired(refreshToken);
+    } catch (ExpiredJwtException e) {
+      throw new RefreshException(RefreshErrorStatus.REFRESH_EXPIRED);
+    }
+
+    // 토큰이 refresh 인지 확인
+    String category = jwtUtil.findCategory(refreshToken);
+    if (!category.equals("refresh")) {
+      throw new RefreshException(RefreshErrorStatus.REFRESH_INVALID);
+    }
+  }
+
+  public NewAccessResponse newAccessToken(HttpServletRequest request) {
+    String refreshToken = jwtUtil.findToken(request, "refresh");
+    checkRefresh(refreshToken);
+
+    String email = jwtUtil.findEmail(refreshToken);
+    String role = jwtUtil.findRole(refreshToken);
+
+    return new NewAccessResponse(jwtUtil.createJwt("access", email, role));
+  }
+
+  @Transactional
+  @Scheduled(cron = "0 0 0 * * *")
+  public void refreshCleanup() {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    refreshRepository.deleteByRefreshExpirationBefore(now);
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/type/RefreshErrorStatus.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/type/RefreshErrorStatus.java
@@ -1,0 +1,37 @@
+package com.zerobase.plistbackend.module.refresh.type;
+
+import com.zerobase.plistbackend.common.app.exception.ErrorStatus;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum RefreshErrorStatus implements ErrorStatus {
+
+  REFRESH_NOT_FOUND(
+      HttpStatus.NOT_FOUND.value(),
+      HttpStatus.NOT_FOUND.getReasonPhrase(),
+      "해당 리프레시 토큰은 존재하지 않습니다."
+  ),
+
+  REFRESH_EXPIRED(
+      HttpStatus.BAD_REQUEST.value(),
+      HttpStatus.BAD_REQUEST.getReasonPhrase(),
+      "해당 리프레시 토큰은 만료되었습니다."
+  ),
+
+  REFRESH_INVALID(
+      HttpStatus.BAD_REQUEST.value(),
+      HttpStatus.BAD_REQUEST.getReasonPhrase(),
+      "해당 토큰은 리프레시 토큰이 아닙니다."
+  );
+
+  private final int errorCode;
+  private final String errorType;
+  private final String message;
+
+  RefreshErrorStatus(int errorCode, String errorType, String message) {
+    this.errorCode = errorCode;
+    this.errorType = errorType;
+    this.message = message;
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/jwt/JwtUtil.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/jwt/JwtUtil.java
@@ -107,8 +107,7 @@ public class JwtUtil {
         .path("/")
         .secure(true)
         .httpOnly(true)
-//        .sameSite("None")
-        .domain(".vercel.app")
+        .sameSite("None")
         .build();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/oauth2/CustomSuccessHandler.java
@@ -1,9 +1,8 @@
 package com.zerobase.plistbackend.module.user.oauth2;
 
-import com.zerobase.plistbackend.module.refresh.service.RefreshService;
+import com.zerobase.plistbackend.module.refresh.service.RefreshServiceImpl;
 import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,7 +22,7 @@ import org.springframework.stereotype.Component;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
   private final JwtUtil jwtUtil;
-  private final RefreshService refreshService;
+  private final RefreshServiceImpl refreshService;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -46,12 +45,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     ResponseCookie cookie = jwtUtil.createCookie("refresh", refresh);
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-//    String url = String.format("https://plist-veta96s-projects.vercel.app/auth/redirect?access-token=%s&is-member=%s",
-    String url = String.format("http://localhost:3000/auth/redirect?access-token=%s&is-member=%s",
-//    String url = String.format("http://localhost:8080/",
+    String url = String.format("https://api.plist.shop/auth/redirect?access-token=%s&is-member=%s",
         access, customOAuth2User.findIsMember());
     response.sendRedirect(url);
   }
-
 
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/RefreshServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/RefreshServiceTest.java
@@ -1,0 +1,113 @@
+package com.zerobase.plistbackend.module.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.plistbackend.module.refresh.dto.NewAccessResponse;
+import com.zerobase.plistbackend.module.refresh.entity.Refresh;
+import com.zerobase.plistbackend.module.refresh.exception.RefreshException;
+import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
+import com.zerobase.plistbackend.module.refresh.service.RefreshServiceImpl;
+import com.zerobase.plistbackend.module.refresh.type.RefreshErrorStatus;
+import com.zerobase.plistbackend.module.user.entity.User;
+import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
+import com.zerobase.plistbackend.module.user.repository.UserRepository;
+import com.zerobase.plistbackend.module.user.type.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshServiceTest {
+
+  private RefreshRepository refreshRepository;
+  private UserRepository userRepository;
+  private JwtUtil jwtUtil;
+  private RefreshServiceImpl refreshService;
+
+  @BeforeEach
+  void setUp() {
+    refreshRepository = Mockito.mock(RefreshRepository.class);
+    userRepository = Mockito.mock(UserRepository.class);
+    jwtUtil = Mockito.mock(JwtUtil.class);
+    refreshService = new RefreshServiceImpl(refreshRepository, userRepository, jwtUtil);
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰 발행 - 성공")
+  void addRefreshEntity_ShouldUpdateExistingRefresh() {
+    String email = "test@example.com";
+    String token = "newRefreshToken";
+    Timestamp expired = new Timestamp(System.currentTimeMillis() + 10000);
+
+    User mockUser = User.builder()
+        .userId(1L)
+        .userEmail(email)
+        .userName("Test User")
+        .userImage("test-image-url")
+        .userRole(UserRole.ROLE_USER)
+        .build();
+
+    Refresh existingRefresh = Refresh.builder()
+        .user(mockUser)
+        .refreshToken(token)
+        .refreshExpiration(expired)
+        .build();
+    existingRefresh.updateRefreshToken("oldToken", expired);
+
+    when(refreshRepository.findByUser_UserEmail(email)).thenReturn(Optional.of(existingRefresh));
+
+    refreshService.addRefreshEntity(email, token, expired);
+
+    assertEquals(token, existingRefresh.getRefreshToken());
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰이 없음 - 오류 확인")
+  void checkRefresh_ShouldThrowExceptionWhenTokenIsNull() {
+    RefreshException exception = assertThrows(RefreshException.class,
+        () -> refreshService.checkRefresh(null));
+    assertEquals(RefreshErrorStatus.REFRESH_NOT_FOUND, exception.getErrorStatus());
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰 만료 - 오류 확인")
+  void checkRefresh_ShouldThrowExceptionWhenTokenIsExpired() {
+    String refreshToken = "expiredToken";
+    doThrow(new RefreshException(RefreshErrorStatus.REFRESH_EXPIRED)).when(jwtUtil)
+        .isExpired(refreshToken);
+
+    RefreshException exception = assertThrows(RefreshException.class,
+        () -> refreshService.checkRefresh(refreshToken));
+    assertEquals(RefreshErrorStatus.REFRESH_EXPIRED, exception.getErrorStatus());
+  }
+
+  @Test
+  @DisplayName("액세스 토큰 재발행 - 성공")
+  void newAccessToken_ShouldReturnNewAccessResponse() {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    String refreshToken = "validToken";
+    String email = "test@example.com";
+    String role = "USER";
+    String accessToken = "newAccessToken";
+
+    when(jwtUtil.findToken(request, "refresh")).thenReturn(refreshToken);
+    when(jwtUtil.isExpired(refreshToken)).thenReturn(false);
+    when(jwtUtil.findEmail(refreshToken)).thenReturn(email);
+    when(jwtUtil.findRole(refreshToken)).thenReturn(role);
+    when(jwtUtil.findCategory(refreshToken)).thenReturn("refresh");
+    when(jwtUtil.createJwt("access", email, role)).thenReturn(accessToken);
+
+    NewAccessResponse response = refreshService.newAccessToken(request);
+
+    assertEquals(accessToken, response.accessToken());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 이전 url 리다이렉트
- 쿠키 설정 비활성화
- 리프레시 만료시 삭제 서비스 부재

**TO-BE**
- redirect uri -> 프론트 주소로 이전
- cookie 설정 중 same site 가 아니어도 쿠키가 입력될 수 있도록 허용
- 매일 자정 리프레시 토큰 순회하면서 만료가 된 토큰 삭제 스케쥴러 서비스 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
