### PR TITLE
chore : CICD 스크립트 수정

### DIFF
--- a/.github/workflows/PlistCICD.yml
+++ b/.github/workflows/PlistCICD.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- 기존에 PR한 뒤에 Merge를 하게 될 경우 배포가 2번씩 되던 현상이 있었는데 조건문으로 이를 막았습니다. 그래서 PR -> Merge 이벤트 발생 시 딱 한번만 배포 될 수있도록 수정했습니다.

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 기존 PR -> Merge시 배포가 연속 2번 되던 버그

**TO-BE**

- 기존 PR -> Merge시 배포가 연속 2번 되던 버그 수정
   - 조건문으로 이를 막아서 PR -> Merge가 일어나도 한번만 배포 될 수 있도록 수정했습니다 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
