### PR TITLE
Bugfix/playlist crud event

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -4,7 +4,10 @@ import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +35,8 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
       @Param("channelStatus") ChannelStatus channelStatus);
 
   Optional<Channel> findByChannelIdAndChannelHostId(Long channelId, Long userId);
+
+   @Lock(LockModeType.PESSIMISTIC_WRITE)
+   @Query("select c from Channel c where c.channelId = :channelId")
+   Optional<Channel> findByIdWithLock(@Param("channelId") Long channelId);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -37,6 +37,6 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
   Optional<Channel> findByChannelIdAndChannelHostId(Long channelId, Long userId);
 
    @Lock(LockModeType.PESSIMISTIC_WRITE)
-   @Query("select c from Channel c where c.channelId = :channelId")
+   @Query("select c from Channel c join fetch c.channelPlaylist where c.channelId = :channelId")
    Optional<Channel> findByIdWithLock(@Param("channelId") Long channelId);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/playlist/domain/PlaylistCrudEventPublisher.java
+++ b/src/main/java/com/zerobase/plistbackend/module/playlist/domain/PlaylistCrudEventPublisher.java
@@ -6,6 +6,7 @@ import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Component;
 public class PlaylistCrudEventPublisher {
 
   private final ChannelService channelService;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final SimpMessageSendingOperations messagingTemplate;
 
   @EventListener
   public void handlePlaylistUpdateEvent(PlaylistCrudEvent event) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 플리방 비디오 추가 및 삭제, 순서변경 시 동시성 이슈 발생가능성 및 쿼리 최적화에 대한 처리

**TO-BE**

- 해당 이벤트 발생 시 비관적 락을 걸어 데이터의 정합성 보장.
   - 추후  데드락 발생 시 비디오의 추가 및 삭제, 순서변경 메서드 호출 직전에 락을 거는 것으로 코드 리팩토링
      - 해당 방식으로 하게 될 경우 channel을 찾게 되는 쿼리가 2번 발생하게 됩니다.
      - 혹은 Redisson락을 이용해 데드락 발생 시 락을 재획득 하는 추가 로직을 고려할 수도 있습니다.   
- Channel과 1:1 관계인 Playlist를 가져올 때 함께 가져올 수 있도록 fetch join 적용

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
