### PR TITLE
Refactor/redis2

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
@@ -12,18 +12,21 @@ public class RefreshRepository {
   private final RedisTemplate<String, Object> redisTemplate;
 
   private static final Long EXPIRATION_TIME = 478800000L;
-  //private static final Long EXPIRATION_TIME = 10L;
 
   public void saveToken(Long userId, String token) {
-    redisTemplate.opsForValue().set(token, userId.toString(), EXPIRATION_TIME, TimeUnit.SECONDS);
+    redisTemplate.opsForValue().set(userId.toString(), token, EXPIRATION_TIME, TimeUnit.SECONDS);
   }
 
-  public Boolean hasToken(String token) {
-    return redisTemplate.hasKey(token);
+  public Boolean hasToken(Long userId) {
+    return redisTemplate.hasKey(userId.toString());
   }
 
-  public void deleteByToken(String refreshToken) {
-    redisTemplate.delete(refreshToken);
+  public String findTokenByUserId(Long userId) {
+    return redisTemplate.opsForValue().get(userId.toString()).toString();
+  }
+
+  public void deleteByToken(Long userId) {
+    redisTemplate.delete(userId.toString());
   }
 
 }

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/repository/RefreshRepository.java
@@ -1,5 +1,7 @@
 package com.zerobase.plistbackend.module.refresh.repository;
 
+import com.zerobase.plistbackend.module.refresh.exception.RefreshException;
+import com.zerobase.plistbackend.module.refresh.type.RefreshErrorStatus;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,7 +24,11 @@ public class RefreshRepository {
   }
 
   public String findTokenByUserId(Long userId) {
-    return redisTemplate.opsForValue().get(userId.toString()).toString();
+    Object token = redisTemplate.opsForValue().get(userId.toString());
+    if (token == null) {
+      throw new RefreshException(RefreshErrorStatus.REFRESH_NOT_FOUND);
+    }
+    return token.toString();
   }
 
   public void deleteByToken(Long userId) {

--- a/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/refresh/service/RefreshServiceImpl.java
@@ -7,6 +7,7 @@ import com.zerobase.plistbackend.module.refresh.type.RefreshErrorStatus;
 import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,11 @@ public class RefreshServiceImpl implements RefreshService {
     // 토큰이 refresh 인지 확인
     String category = jwtUtil.findCategory(refreshToken);
     if (!category.equals("refresh")) {
+      throw new RefreshException(RefreshErrorStatus.REFRESH_INVALID);
+    }
+
+    Long userId = jwtUtil.findId(refreshToken);
+    if (!Objects.equals(refreshRepository.findTokenByUserId(userId), refreshToken)) {
       throw new RefreshException(RefreshErrorStatus.REFRESH_INVALID);
     }
   }

--- a/src/main/java/com/zerobase/plistbackend/module/user/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/jwt/CustomLogoutFilter.java
@@ -62,8 +62,9 @@ public class CustomLogoutFilter extends GenericFilterBean {
       return;
     }
 
-    if (refreshRepository.hasToken(refresh)) {
-      refreshRepository.deleteByToken(refresh);
+    Long userId = jwtUtil.findId(refresh);
+    if (refreshRepository.hasToken(userId)) {
+      refreshRepository.deleteByToken(userId);
     } else {
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
redis token 저장 포맷 key : token, value : id 로 설정되어 있어 같은 user id 로 발급되는 token 이 생길 수 있음
재발급 과정에서 토큰 검증 부분 중 token 의 값이 저장되어 있는 토큰이 맞는지 확인 로직 부재

**TO-BE**
- redis token 저장 시 key : userId, value : token 으로 저장하도록 설정
- 로그아웃 시 token 에서 userId 를 확인 후 redis 에서 삭제할 수 있도록 변경
- refresh 검증 부분에서 요청받은 토큰 값과 저장되어 있는 토큰 값이 맞는지 확인하는 로직 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
