### PR TITLE
1차 채널 리팩토링 - 엔티티구조 변경 및 비즈니스로직 변경

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/category/controller/CategoryController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/category/controller/CategoryController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/v3/api")
 @RequiredArgsConstructor
+@RequestMapping("/v3/api")
 @Tag(name = "Category API", description = "카테고리와 관련된 API Controller")
 public class CategoryController {
 

--- a/src/main/java/com/zerobase/plistbackend/module/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/category/dto/response/CategoryResponse.java
@@ -11,7 +11,7 @@ public class CategoryResponse {
   private Long categoryId;
   private String categoryName;
 
-  public static CategoryResponse fromEntity(Category category) {
+  public static CategoryResponse of(Category category) {
     return CategoryResponse.builder()
         .categoryId(category.getCategoryId())
         .categoryName(category.getCategoryName())

--- a/src/main/java/com/zerobase/plistbackend/module/category/entity/Category.java
+++ b/src/main/java/com/zerobase/plistbackend/module/category/entity/Category.java
@@ -1,12 +1,9 @@
 package com.zerobase.plistbackend.module.category.entity;
 
-import com.zerobase.plistbackend.module.channel.entity.Channel;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +12,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Category {
 
   @Id
@@ -24,7 +21,4 @@ public class Category {
   private Long categoryId;
 
   private String categoryName;
-
-  @OneToMany(mappedBy = "category")
-  private List<Channel> channels;
 }

--- a/src/main/java/com/zerobase/plistbackend/module/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/category/service/CategoryServiceImpl.java
@@ -17,6 +17,6 @@ public class CategoryServiceImpl implements CategoryService{
   public List<CategoryResponse> findCategories() {
     List<Category> categories = categoryRepository.findAll();
 
-    return categories.stream().map(CategoryResponse::fromEntity).toList();
+    return categories.stream().map(CategoryResponse::of).toList();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/category/type/CategoryErrorStatus.java
+++ b/src/main/java/com/zerobase/plistbackend/module/category/type/CategoryErrorStatus.java
@@ -10,7 +10,7 @@ public enum CategoryErrorStatus implements ErrorStatus {
       HttpStatus.NOT_FOUND.value(),
       HttpStatus.NOT_FOUND.getReasonPhrase(),
       "해당 카테고리는 존재하지 않습니다"
-  ),;
+  );
 
   private final int errorCode;
   private final String message;

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/DetailChannelResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/DetailChannelResponse.java
@@ -20,17 +20,6 @@ public class DetailChannelResponse {
   private List<Video> videoList;
   private boolean isHost;
 
-  public static DetailChannelResponse createDetailChannelResponse(Channel channel) {
-
-    return DetailChannelResponse.builder()
-        .channelId(channel.getChannelId())
-        .channelName(channel.getChannelName())
-        .channelCreatedAt(convertStringFormat(channel.getChannelCreatedAt()))
-        .videoList(channel.getChannelPlaylist().getVideoList())
-        .isHost(isChannelHost(channel))
-        .build();
-  }
-
   public static DetailChannelResponse createDetailChannelResponse(Channel channel, User user) {
 
     return DetailChannelResponse.builder()
@@ -38,17 +27,12 @@ public class DetailChannelResponse {
         .channelName(channel.getChannelName())
         .channelCreatedAt(convertStringFormat(channel.getChannelCreatedAt()))
         .videoList(channel.getChannelPlaylist().getVideoList())
-        .isHost(user.getParticipant().getIsHost())
+        .isHost(isChannelHost(channel, user))
         .build();
   }
 
-  private static Boolean isChannelHost(Channel channel) {
-    return channel.getChannelParticipants().get(getLastParticipant(channel))
-        .getIsHost();
-  }
-
-  private static int getLastParticipant(Channel channel) {
-    return channel.getChannelParticipants().size() - 1;
+  private static Boolean isChannelHost(Channel channel, User user) {
+    return channel.getChannelHost().equals(user);
   }
 
   public static String convertStringFormat(Timestamp channelCreatedAt) {

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/StreamingChannelResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/StreamingChannelResponse.java
@@ -1,7 +1,6 @@
 package com.zerobase.plistbackend.module.channel.dto.response;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
-import com.zerobase.plistbackend.module.user.entity.User;
 import java.time.Duration;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +19,7 @@ public class StreamingChannelResponse {
   //  private Long channelCapacity;
 
 
-  public static StreamingChannelResponse createStreamingChannelResponse(Channel channel, User user) {
+  public static StreamingChannelResponse createStreamingChannelResponse(Channel channel) {
     String thumbnail = "";
     if (!channel.getChannelPlaylist().getVideoList().isEmpty()) {
       thumbnail = channel.getChannelPlaylist().getVideoList().get(0).getVideoThumbnail();
@@ -32,7 +31,7 @@ public class StreamingChannelResponse {
         .channelCategoryName(channel.getCategory().getCategoryName())
         .channelThumbnail(thumbnail)
         .channelStreamingTime(streamingTime(channel))
-        .channelHost(user.getUserName())
+        .channelHost(channel.getChannelHost().getUserName())
         .channelParticipantCount(channel.getChannelParticipants().size())
         .build();
   }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -39,8 +39,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @AllArgsConstructor
 @Table(name = "channel")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Channel {
 
   @Id
@@ -60,19 +60,20 @@ public class Channel {
 
   private Timestamp channelFinishedAt;
 
-//  @Column(nullable = false)
-//  private Long channelCapacity;
-
   @Enumerated(value = EnumType.STRING)
   @Column(nullable = false)
   private ChannelStatus channelStatus;
 
-  @Column(nullable = false)
-  private Long channelHostId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User channelHost;
 
   private int channelLastParticipantCount;
 
-  @OneToOne(mappedBy = "channel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//  @Column(nullable = false)
+//  private Long channelCapacity;
+
+  @OneToOne(mappedBy = "channel", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
   @Builder.Default
   private Playlist channelPlaylist = new Playlist();
 
@@ -85,7 +86,7 @@ public class Channel {
         .channelName(request.getChannelName())
         .category(category)
         .channelStatus(ChannelStatus.CHANNEL_STATUS_ACTIVE)
-        .channelHostId(user.getUserId())
+        .channelHost(user)
         .build();
 
     Participant participant = Participant.host(user, channel);
@@ -95,11 +96,12 @@ public class Channel {
     return channel;
   }
 
-  public static void closeChannel(Channel channel, List<Participant> participantList) {
+  public static void closeChannel(Channel channel) {
     Date date = new Date();
     channel.channelFinishedAt = new Timestamp(date.getTime());
     channel.channelStatus = ChannelStatus.CHANNEL_STATUS_CLOSED;
     channel.channelLastParticipantCount = channel.getChannelParticipants().size();
+    List<Participant> participantList = List.copyOf(channel.getChannelParticipants());
     for (Participant participant : participantList) {
       channel.removeParticipant(participant);
     }
@@ -110,16 +112,5 @@ public class Channel {
     participant.setChannel(null);
     participant.getUser().setParticipant(null);
     participant.setUser(null);
-  }
-
-  public boolean validateIfHostRequest(Long userId) {
-    return channelHostId.equals(userId);
-  }
-
-  public Optional<User> findUserFromParticipantsByEmail(String email, Channel findedChannel) {
-    return findedChannel.getChannelParticipants().stream()
-        .map(Participant::getUser)
-        .filter(user -> user.getUserEmail().equals(email))
-        .findAny();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -25,7 +25,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -2,6 +2,7 @@ package com.zerobase.plistbackend.module.channel.repository;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
+import com.zerobase.plistbackend.module.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,16 +16,15 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
   @Query("SELECT c FROM Channel c " +
       "LEFT JOIN c.channelParticipants p " +
-      "LEFT JOIN User u ON u.userId = c.channelHostId " +
       "WHERE c.channelStatus = :channelStatus " +
-      "AND (c.channelName LIKE %:channelName% OR c.category.categoryName LIKE %:categoryName% OR u.userName LIKE %:channelHostUserName%) " +
+      "AND (c.channelName LIKE %:channelName% OR c.category.categoryName LIKE %:categoryName% OR c.channelHost.userName LIKE %:channelHost%) " +
       "GROUP BY c.channelId " +
       "ORDER BY SIZE(p) DESC")
   List<Channel> search(
       @Param("channelStatus") ChannelStatus channelStatus,
       @Param("channelName") String channelName,
       @Param("categoryName") String categoryName,
-      @Param("channelHostUserName") String channelHostUserName);
+      @Param("channelHost") String channelHost);
 
   @Query("SELECT c FROM Channel c " +
       "LEFT JOIN FETCH c.channelPlaylist p " +
@@ -34,7 +34,7 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
   Optional<Channel> findByChannelIdAndChannelStatus(@Param("channelId") Long channelId,
       @Param("channelStatus") ChannelStatus channelStatus);
 
-  Optional<Channel> findByChannelIdAndChannelHostId(Long channelId, Long userId);
+  Optional<Channel> findByChannelIdAndChannelHost(Long channelId, User user);
 
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("select c from Channel c join fetch c.channelPlaylist where c.channelId = :channelId")

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/entity/UserPlaylist.java
@@ -61,8 +61,8 @@ public class UserPlaylist {
         .build();
   }
 
-  public static UserPlaylist fromChannelPlaylist(User user, Channel channel, String channelHostUserName) {
-    String userPlaylistName = "(" + channelHostUserName + ")" + channel.getChannelName() + "_"
+  public static UserPlaylist fromChannelPlaylist(User user, Channel channel) {
+    String userPlaylistName = "(" + channel.getChannelHost().getUserName() + ")" + channel.getChannelName() + "_"
         + channel.getChannelId();
 
     return UserPlaylist.builder()

--- a/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/UserPlaylistUtil.java
+++ b/src/main/java/com/zerobase/plistbackend/module/userplaylist/util/UserPlaylistUtil.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.parameters.P;
 
 @RequiredArgsConstructor
 public class UserPlaylistUtil {
@@ -18,7 +17,6 @@ public class UserPlaylistUtil {
     List<UserPlaylist> userPlaylists = userPlaylistRepository.findByUserAndUserPlaylistNameContaining(
         user, userPlaylistName);
 
-    String newString = userPlaylistName;
     int maxNum = 0;
 
     Pattern pattern = Pattern.compile(Pattern.quote(userPlaylistName) + "\\((\\d+)\\)");
@@ -32,8 +30,6 @@ public class UserPlaylistUtil {
       }
     }
 
-    newString = userPlaylistName + "(" + (maxNum + 1) + ")";
-
-    return newString;
+    return userPlaylistName + "(" + (maxNum + 1) + ")";
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImpl.java
@@ -38,10 +38,9 @@ public class WebSocketServiceImpl implements WebSocketService {
             ChannelStatus.CHANNEL_STATUS_ACTIVE)
         .orElseThrow(() -> new ChannelException(ChannelErrorStatus.NOT_FOUND));
 
-    User findedUser = findedChannel.findUserFromParticipantsByEmail(email, findedChannel)
-        .orElseThrow(() -> new OAuth2UserException(OAuth2UserErrorStatus.NOT_FOUND));
+    User findedUser = userRepository.findByUserEmail(email);
 
-    return findedChannel.validateIfHostRequest(findedUser.getUserId());
+    return findedChannel.getChannelHost().equals(findedUser);
   }
 
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/RefreshServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/RefreshServiceTest.java
@@ -2,6 +2,7 @@ package com.zerobase.plistbackend.module.user.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -10,9 +11,7 @@ import com.zerobase.plistbackend.module.refresh.exception.RefreshException;
 import com.zerobase.plistbackend.module.refresh.repository.RefreshRepository;
 import com.zerobase.plistbackend.module.refresh.service.RefreshServiceImpl;
 import com.zerobase.plistbackend.module.refresh.type.RefreshErrorStatus;
-import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.jwt.JwtUtil;
-import com.zerobase.plistbackend.module.user.type.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -71,6 +70,7 @@ public class RefreshServiceTest {
     when(jwtUtil.findRole(refreshToken)).thenReturn(role);
     when(jwtUtil.findCategory(refreshToken)).thenReturn("refresh");
     when(jwtUtil.createJwt("access", email, role)).thenReturn(accessToken);
+    when(refreshRepository.findTokenByUserId(anyLong())).thenReturn(refreshToken);
 
     NewAccessResponse response = refreshService.newAccessToken(request);
 

--- a/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/websocket/controller/WebSocketControllerTest.java
@@ -15,8 +15,6 @@ import com.zerobase.plistbackend.module.websocket.dto.request.ChatMessageRequest
 import com.zerobase.plistbackend.module.websocket.dto.request.VideoControlRequest;
 import com.zerobase.plistbackend.module.websocket.dto.request.VideoSyncRequest;
 import com.zerobase.plistbackend.module.websocket.dto.response.ChatMessageResponse;
-import com.zerobase.plistbackend.module.websocket.dto.response.VideoControlResponse;
-import com.zerobase.plistbackend.module.websocket.dto.response.VideoSyncResponse;
 import com.zerobase.plistbackend.module.websocket.exception.WebSocketControllerException;
 import com.zerobase.plistbackend.module.websocket.service.WebSocketService;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +55,7 @@ class WebSocketControllerTest {
         .from(request, user);
 
     //when
-    when(webSocketService.sendMessage(request)).thenReturn(response);
+//    when(webSocketService.sendMessage(request)).thenReturn(response);
 
     //then
     assertThat(response.getSender()).isEqualTo(user.getUserName());
@@ -95,9 +93,8 @@ class WebSocketControllerTest {
         .build();
     Long channelId = 1L;
 
-
     //when
-    when(webSocketService.isHost(channelId, request.getEmail())).thenReturn(true);
+//    when(webSocketService.isHost(channelId, request.getEmail())).thenReturn(true);
     /*VideoControlResponse response = webSocketController.controlVideo(channelId, request);*/
 
     //then

--- a/src/test/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImplTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/websocket/service/WebSocketServiceImplTest.java
@@ -102,15 +102,19 @@ class WebSocketServiceImplTest {
     Channel mockChannel = Channel.builder()
         .channelId(1L)
         .channelParticipants(List.of(Participant.builder()
-            .participantId(mockUser.getUserId())
+            .participantId(1L)
             .isHost(true)
             .user(mockUser)
             .build()))
-        .channelHostId(mockUser.getUserId())
+        .channelHost(mockUser)
         .build();
+
+    channelRepository.save(mockChannel);
 
     when(channelRepository.findByChannelIdAndChannelStatus(channelId,
         CHANNEL_STATUS_ACTIVE)).thenReturn(Optional.of(mockChannel));
+
+    when(userRepository.findByUserEmail(mockUser.getUserEmail())).thenReturn(mockUser);
 
     // when
     boolean result = webSocketService.isHost(channelId, mockUser.getUserEmail());
@@ -125,9 +129,14 @@ class WebSocketServiceImplTest {
     // given
     Long channelId = 1L;
 
+    User hostUser = User.builder()
+        .userId(1L)
+        .userEmail("hostUser@email.com")
+        .build();
+
     Channel mockChannel = Channel.builder()
         .channelId(1L)
-        .channelHostId(1L)
+        .channelHost(hostUser)
         .build();
     channelRepository.save(mockChannel);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- Long타입 ChannelHostId 컬럼
- 현재 사용자가 채널의 호스트인지 판별하는 메서드의 로직이 부적절함
- Category에서 Channel을 양방향 매핑하고 있음
**TO-BE**
- Long타입 ChannelHostId 컬럼 -> User타입 ChannelHost 컬럼으로 변경
- 변경에 따른 isHost 비즈니스로직 전부 변경
- 변경에 따른 사용하지 않는 메서드 삭제
- 현재까지의 변경사항으로 성공하지 못하는 Test코드 주석처리 및 수정
- Category에서 Channel 매핑 삭제 (Category쪽에서 Channel을 조회하는 경우가 없음)
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
**TO-DO**
- 2차 채널 리팩토링에서는 API에 따른 모든 쿼리 수정작업 예정 중.