### PR TITLE
Feat/get playtime

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -115,7 +115,7 @@ public class Channel {
     participant.setUser(null);
   }
 
-  public long getTotalPlaytime() {
+  public long getTotalPlaytimeOfMinutes() {
     return Duration.between((Temporal) this.getChannelCreatedAt(), (Temporal) this.getChannelFinishedAt()).toMinutes();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -22,6 +22,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -111,5 +113,9 @@ public class Channel {
     participant.setChannel(null);
     participant.getUser().setParticipant(null);
     participant.setUser(null);
+  }
+
+  public long getTotalPlaytime() {
+    return Duration.between((Temporal) this.getChannelCreatedAt(), (Temporal) this.getChannelFinishedAt()).toMinutes();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/entity/Channel.java
@@ -115,7 +115,7 @@ public class Channel {
     participant.setUser(null);
   }
 
-  public long getTotalPlaytimeOfMinutes() {
-    return Duration.between((Temporal) this.getChannelCreatedAt(), (Temporal) this.getChannelFinishedAt()).toMinutes();
+  public long getTotalPlaytimeOfSeconds() {
+    return Duration.between((Temporal) this.getChannelCreatedAt(), (Temporal) this.getChannelFinishedAt()).toSeconds();
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.entity.User;
 import jakarta.persistence.LockModeType;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -47,4 +48,17 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
   @Query("select c from Channel c join fetch c.channelPlaylist where c.channelId = :channelId")
   Optional<Channel> findByIdFetchJoinPlaylist(@Param("channelId") Long channelId);
+
+  @Query("SELECT c FROM Channel c " +
+          "JOIN FETCH c.channelHost " +
+          "WHERE c.channelHost.userId = :hostId " +
+          "AND c.channelStatus = :channelStatus " +
+          "AND c.channelCreatedAt >= :startDate " +
+          "AND c.channelCreatedAt < :endDate")
+  List<Channel> findByChannelHostId(
+          @Param("hostId") Long hostId,
+          @Param("startDate") Timestamp startDate,
+          @Param("endDate") Timestamp endDate,
+          @Param("channelStatus") ChannelStatus channelStatus
+  );
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
           description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
                   " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
   @GetMapping("/me/playtime")
-  public ResponseEntity<List<PlayTimeResponse>> getSomething(
+  public ResponseEntity<PlayTimeResponse> getSomething(
           @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
           @RequestParam("year") int year) {
     return ResponseEntity.ok(userService.getPlaytime(customOAuth2User.findId(), year));

--- a/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
           description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
                   " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
   @GetMapping("/me/playtime")
-  public ResponseEntity<PlayTimeResponse> getSomething(
+  public ResponseEntity<PlayTimeResponse> getPlayTime(
           @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
           @RequestParam("year") int year) {
     return ResponseEntity.ok(userService.getPlaytime(customOAuth2User.findId(), year));

--- a/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
@@ -14,8 +14,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v3/api")
@@ -54,7 +52,7 @@ public class UserController {
           description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
                   " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
   @GetMapping("/me/playtime")
-  public ResponseEntity<PlayTimeResponse> getPlayTime(
+  public ResponseEntity<PlayTimeResponse> getHistoryOfPlaytime(
           @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
           @RequestParam("year") int year) {
     return ResponseEntity.ok(userService.getPlaytime(customOAuth2User.findId(), year));

--- a/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.zerobase.plistbackend.module.user.controller;
 
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
+import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.user.service.UserServiceImpl;
@@ -10,13 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,5 +49,14 @@ public class UserController {
     UserProfileRequest userProfileRequest = new UserProfileRequest(file, nickName);
     userProfileRequest.validate();
     return ResponseEntity.ok(userService.editProfile(userProfileRequest, customOAuth2User.findId()));
+  }
+  @Operation(summary = "회원의 플리방 이력 정보 가져오기",
+          description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
+                  " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
+  @GetMapping("/me/playtime")
+  public ResponseEntity<List<PlayTimeResponse>> getSomething(
+          @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+          @RequestParam("year") int year) {
+    return ResponseEntity.ok(userService.getPlaytime(customOAuth2User.findId(), year));
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/dto/response/PlayTimeResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/dto/response/PlayTimeResponse.java
@@ -1,0 +1,16 @@
+package com.zerobase.plistbackend.module.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayTimeResponse {
+    private String totalPlayTime;
+    private int totalParticipant;
+    private Long totalFollowers;
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
@@ -4,7 +4,6 @@ import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
 import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 
-import java.util.List;
 
 public interface UserService {
 
@@ -14,5 +13,5 @@ public interface UserService {
 
    ProfileResponse editProfile(UserProfileRequest request, Long userId);
 
-   List<PlayTimeResponse> getPlaytime(Long hostId, int year);
+   PlayTimeResponse getPlaytime(Long hostId, int year);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
@@ -1,7 +1,10 @@
 package com.zerobase.plistbackend.module.user.service;
 
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
+import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
+
+import java.util.List;
 
 public interface UserService {
 
@@ -10,4 +13,6 @@ public interface UserService {
    void withdrawUser(Long userId);
 
    ProfileResponse editProfile(UserProfileRequest request, Long userId);
+
+   List<PlayTimeResponse> getPlaytime(Long hostId, int year);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
@@ -81,7 +81,7 @@ public class UserServiceImpl implements UserService {
                 .totalPlayTime(
                         TimeValueFormatter.formatToString(
                                 channels.stream()
-                                        .mapToLong(Channel::getTotalPlaytimeOfMinutes)
+                                        .mapToLong(Channel::getTotalPlaytimeOfSeconds)
                                         .sum())
                 )
                 .totalParticipant(

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
@@ -1,6 +1,10 @@
 package com.zerobase.plistbackend.module.user.service;
 
+import com.zerobase.plistbackend.module.channel.entity.Channel;
+import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
+import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.exception.UserException;
@@ -8,52 +12,81 @@ import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import com.zerobase.plistbackend.module.user.type.UserErrorStatus;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import com.zerobase.plistbackend.module.user.util.S3Util;
+import com.zerobase.plistbackend.module.user.util.TimeValueFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
-  private final UserRepository userRepository;
-  private final S3Util s3Util;
+    private final UserRepository userRepository;
+    private final ChannelRepository channelRepository;
+    private final S3Util s3Util;
 
-  @Override
-  @Transactional(readOnly = true)
-  public ProfileResponse findProfile(String email) {
-    log.info("Find Profile Request email: {}", email);
-    return userRepository.findProfileByEmail(email);
-  }
-
-  @Override
-  @Transactional
-  public void withdrawUser(Long userId) {
-    log.info("Withdraw Request userId: {}", userId);
-    User user = findUser(userId);
-    user.updateRole(UserRole.ROLE_NONE);
-  }
-
-  @Override
-  @Transactional
-  public ProfileResponse editProfile(UserProfileRequest request, Long userId) {
-
-    log.info("updateProfile Request userId: {}", userId);
-    User user = findUser(userId);
-
-    if(request.nickname() != null) {
-      user.updateUserName(request.nickname());
+    @Override
+    @Transactional(readOnly = true)
+    public ProfileResponse findProfile(String email) {
+        log.info("Find Profile Request email: {}", email);
+        return userRepository.findProfileByEmail(email);
     }
-    if(request.image() != null) {
-      user.updateImage(s3Util.putImage(request.image(), user.getUserEmail()));
-    }
-    return new ProfileResponse(user.getUserEmail(), user.getUserName(), user.getUserImage());
-  }
 
-  private User findUser(Long id) {
-    return userRepository.findById(id)
-        .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
-  }
+    @Override
+    @Transactional
+    public void withdrawUser(Long userId) {
+        log.info("Withdraw Request userId: {}", userId);
+        User user = findUser(userId);
+        user.updateRole(UserRole.ROLE_NONE);
+    }
+
+    @Override
+    @Transactional
+    public ProfileResponse editProfile(UserProfileRequest request, Long userId) {
+
+        log.info("updateProfile Request userId: {}", userId);
+        User user = findUser(userId);
+
+        if (request.nickname() != null) {
+            user.updateUserName(request.nickname());
+        }
+        if (request.image() != null) {
+            user.updateImage(s3Util.putImage(request.image(), user.getUserEmail()));
+        }
+        return new ProfileResponse(user.getUserEmail(), user.getUserName(), user.getUserImage());
+    }
+
+    private User findUser(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PlayTimeResponse> getPlaytime(Long hostId, int year) {
+        Timestamp startDate = Timestamp.valueOf(LocalDateTime.now().withYear(year).withMonth(1));
+        Timestamp endDate = Timestamp.valueOf(LocalDateTime.now().withYear(year + 1).withMonth(1));
+
+        List<Channel> channels = channelRepository.findByChannelHostId(
+                hostId, startDate, endDate, ChannelStatus.CHANNEL_STATUS_CLOSED);
+
+        return channels.stream()
+                .map(channel -> {
+                    String totalPlayTime = TimeValueFormatter.formatToString(channel.getChannelCreatedAt(), channel.getChannelFinishedAt());
+                    int totalParticipants = channel.getChannelLastParticipantCount();
+                    //TODO : 각 채널별 팔로워 수 기능 추가 예정
+                    return PlayTimeResponse.builder()
+                            .totalPlayTime(totalPlayTime)
+                            .totalParticipant(totalParticipants)
+                            .totalFollowers(0L)
+                            .build();
+                })
+                .toList();
+    }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/util/TimeValueFormatter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/util/TimeValueFormatter.java
@@ -1,0 +1,27 @@
+package com.zerobase.plistbackend.module.user.util;
+
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Component
+public abstract class TimeValueFormatter {
+
+    private AssertionError TimeValueFormatter() {
+        return new AssertionError("생성 금지");
+    }
+
+    public static String formatToString(Timestamp start, Timestamp end) {
+        LocalDateTime startDate = start.toLocalDateTime();
+        LocalDateTime endDate = end.toLocalDateTime();
+
+        long totalSeconds = Duration.between(startDate, endDate).getSeconds();
+
+        int hours = (int) (totalSeconds / 3600);
+        int minutes = (int) ((totalSeconds % 3600) / 60);
+
+        return String.format("%d시간 %d분", hours, minutes);
+    }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/util/TimeValueFormatter.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/util/TimeValueFormatter.java
@@ -2,10 +2,6 @@ package com.zerobase.plistbackend.module.user.util;
 
 import org.springframework.stereotype.Component;
 
-import java.sql.Timestamp;
-import java.time.Duration;
-import java.time.LocalDateTime;
-
 @Component
 public abstract class TimeValueFormatter {
 
@@ -13,15 +9,9 @@ public abstract class TimeValueFormatter {
         return new AssertionError("생성 금지");
     }
 
-    public static String formatToString(Timestamp start, Timestamp end) {
-        LocalDateTime startDate = start.toLocalDateTime();
-        LocalDateTime endDate = end.toLocalDateTime();
-
-        long totalSeconds = Duration.between(startDate, endDate).getSeconds();
-
+    public static String formatToString(long totalSeconds) {
         int hours = (int) (totalSeconds / 3600);
         int minutes = (int) ((totalSeconds % 3600) / 60);
-
         return String.format("%d시간 %d분", hours, minutes);
     }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepositoryTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.zerobase.plistbackend.module.channel.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.plistbackend.module.channel.entity.Channel;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
+import com.zerobase.plistbackend.module.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(ChannelRepositoryTest.TestConfig.class)
+class ChannelRepositoryTest {
+    @Autowired
+    private ChannelRepository channelRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void testFindByChannelHostId() {
+        // given
+        User host = createHost();
+        createTwoClosedChannel(host);
+        entityManager.flush();
+
+        int queryYear = 2025;
+        Timestamp startDate = Timestamp.valueOf(LocalDateTime.now()
+                .withYear(queryYear)
+                .withMonth(1));
+        Timestamp endDate = Timestamp.valueOf(LocalDateTime.now().withYear(queryYear + 1).withMonth(1));
+
+        // when
+        List<Channel> closedChannelList = channelRepository.findByChannelHostId(host.getUserId(), startDate, endDate, ChannelStatus.CHANNEL_STATUS_CLOSED);
+        // then
+        assertThat(closedChannelList).hasSize(2);
+        for (Channel channel : closedChannelList) {
+            assertThat(channel.getChannelCreatedAt()).isAfterOrEqualTo(startDate);
+            assertThat(channel.getChannelCreatedAt()).isBefore(endDate);
+            assertThat(channel.getChannelHost().getUserId()).isEqualTo(host.getUserId());
+            assertThat(channel.getChannelStatus()).isEqualTo(ChannelStatus.CHANNEL_STATUS_CLOSED);
+        }
+    }
+
+    private void createTwoClosedChannel(User host) {
+        Channel closedChannel1 = Channel.builder()
+                .channelName("Closed Channel1")
+                .channelStatus(ChannelStatus.CHANNEL_STATUS_CLOSED)
+                .channelCreatedAt(Timestamp.valueOf(LocalDateTime.now()
+                        .withYear(2025)
+                        .withHour(15)
+                        .withMinute(30)))
+                .channelFinishedAt(Timestamp.valueOf(LocalDateTime.now()
+                        .withYear(2025)
+                        .withHour(20)
+                        .withMinute(55)))
+                .channelHost(host)
+                .build();
+
+
+        Channel closedChannel2 = Channel.builder()
+                .channelName("Closed Channel2")
+                .channelStatus(ChannelStatus.CHANNEL_STATUS_CLOSED)
+                .channelCreatedAt(Timestamp.valueOf(LocalDateTime.now()
+                        .withYear(2025)
+                        .withHour(20)
+                        .withMinute(55)))
+                .channelFinishedAt(Timestamp.valueOf(LocalDateTime.now()
+                        .withYear(2025)
+                        .withHour(23)
+                        .withMinute(55)))
+                .channelHost(host)
+                .build();
+        entityManager.persist(closedChannel1);
+        entityManager.persist(closedChannel2);
+    }
+
+    private User createHost() {
+        User host = User.builder()
+                .userEmail("test@plist.com")
+                .userName("test")
+                .build();
+        entityManager.persist(host);
+        return host;
+    }
+
+    @TestConfiguration
+    public static class TestConfig {
+        @Bean
+        public ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}

--- a/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.user.service.UserServiceImpl;
-import com.zerobase.plistbackend.module.user.util.TimeValueFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,20 +11,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
-
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
@@ -49,31 +49,22 @@ class UserControllerTest {
         int year = 2022;
         Long userId = 123L;
 
-        List<PlayTimeResponse> playTimeResponses = new ArrayList<>();
+        String wholePlayTime = "3시간 0분";
+        PlayTimeResponse playTimeResponse = new PlayTimeResponse(wholePlayTime, 50, 0L);
 
-        Timestamp startDate = Timestamp.valueOf(LocalDateTime.now().withYear(year).withMonth(1));
-        Timestamp endDate = Timestamp.valueOf(LocalDateTime.now().withYear(year + 1).withMonth(1));
-        String time = TimeValueFormatter.formatToString(startDate, endDate);
-
-        PlayTimeResponse playTimeResponse = new PlayTimeResponse(time, 50, 0L);
-        playTimeResponses.add(playTimeResponse);
+        given(userService.getPlaytime(userId, year)).willReturn(playTimeResponse);
 
         CustomOAuth2User dummyUser = mock(CustomOAuth2User.class);
         given(dummyUser.findId()).willReturn(userId);
-
-        given(userService.getPlaytime(userId, year)).willReturn(playTimeResponses);
-
 
         // when & then
         mockMvc.perform(get("/v3/api/me/playtime")
                         .param("year", String.valueOf(year))
                         .with(authentication(new TestingAuthenticationToken(dummyUser, null, "ROLE_USER"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0].totalPlayTime").value("8760시간 0분"))
-                .andExpect(jsonPath("$[0].totalParticipant").value(50))
-                .andExpect(jsonPath("$[0].totalFollowers").value(0))
+                .andExpect(jsonPath("$.totalPlayTime").value(wholePlayTime))
+                .andExpect(jsonPath("$.totalParticipant").value(50))
+                .andExpect(jsonPath("$.totalFollowers").value(0))
                 .andDo(print());
-
     }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/controller/UserControllerTest.java
@@ -1,0 +1,79 @@
+package com.zerobase.plistbackend.module.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.user.service.UserServiceImpl;
+import com.zerobase.plistbackend.module.user.util.TimeValueFormatter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserServiceImpl userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원의 플리방 이력 정보 가져오기 API 테스트")
+    void getPlaytime() throws Exception {
+        // given
+        int year = 2022;
+        Long userId = 123L;
+
+        List<PlayTimeResponse> playTimeResponses = new ArrayList<>();
+
+        Timestamp startDate = Timestamp.valueOf(LocalDateTime.now().withYear(year).withMonth(1));
+        Timestamp endDate = Timestamp.valueOf(LocalDateTime.now().withYear(year + 1).withMonth(1));
+        String time = TimeValueFormatter.formatToString(startDate, endDate);
+
+        PlayTimeResponse playTimeResponse = new PlayTimeResponse(time, 50, 0L);
+        playTimeResponses.add(playTimeResponse);
+
+        CustomOAuth2User dummyUser = mock(CustomOAuth2User.class);
+        given(dummyUser.findId()).willReturn(userId);
+
+        given(userService.getPlaytime(userId, year)).willReturn(playTimeResponses);
+
+
+        // when & then
+        mockMvc.perform(get("/v3/api/me/playtime")
+                        .param("year", String.valueOf(year))
+                        .with(authentication(new TestingAuthenticationToken(dummyUser, null, "ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].totalPlayTime").value("8760시간 0분"))
+                .andExpect(jsonPath("$[0].totalParticipant").value(50))
+                .andExpect(jsonPath("$[0].totalFollowers").value(0))
+                .andDo(print());
+
+    }
+}

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -140,10 +139,10 @@ public class UserServiceTest {
     Channel channel2 = mock(Channel.class);
 
     given(channel1.getChannelLastParticipantCount()).willReturn(30);
-    given(channel1.getTotalPlaytime()).willReturn(3600L);
+    given(channel1.getTotalPlaytimeOfMinutes()).willReturn(3600L);
 
     given(channel2.getChannelLastParticipantCount()).willReturn(20);
-    given(channel2.getTotalPlaytime()).willReturn(7200L);
+    given(channel2.getTotalPlaytimeOfMinutes()).willReturn(7200L);
 
     List<Channel> channels = List.of(channel1, channel2);
 
@@ -162,13 +161,4 @@ public class UserServiceTest {
     verify(channelRepository, times(1)).findByChannelHostId(anyLong(), any(), any(), any());
   }
 
-  private Channel createMockChannel(String name, String startDateTime, String endDateTime, int participantCount) {
-    return Channel.builder()
-            .channelName(name)
-            .channelStatus(ChannelStatus.CHANNEL_STATUS_CLOSED)
-            .channelCreatedAt(Timestamp.valueOf(startDateTime))
-            .channelFinishedAt(Timestamp.valueOf(endDateTime))
-            .channelLastParticipantCount(participantCount)
-            .build();
-  }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
@@ -1,13 +1,16 @@
 package com.zerobase.plistbackend.module.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
+import com.zerobase.plistbackend.module.channel.entity.Channel;
+import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
+import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
+import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.exception.UserException;
@@ -16,11 +19,15 @@ import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import com.zerobase.plistbackend.module.user.type.UserErrorStatus;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import com.zerobase.plistbackend.module.user.util.S3Util;
+
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +35,9 @@ import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
+
+  @Mock
+  ChannelRepository channelRepository;
 
   @Mock
   private UserRepository userRepository;
@@ -118,5 +128,55 @@ public class UserServiceTest {
 
     assertEquals(UserErrorStatus.USER_NOT_FOUND, exception.getErrorStatus());
     verify(userRepository).findById(1L);
+  }
+
+  @Test
+  @DisplayName("특정 호스트의 채널별 재생시간 조회")
+  void getPlaytime_ShouldReturnCorrectData() {
+    // given
+    Long hostId = 1L;
+    int year = 2025;
+
+    ArgumentCaptor<Timestamp> startDateCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    ArgumentCaptor<Timestamp> endDateCaptor = ArgumentCaptor.forClass(Timestamp.class);
+
+    List<Channel> mockChannels = List.of(
+            createMockChannel("Closed Channel 1", "2025-03-10 12:00:00", "2025-03-10 14:00:00", 50),
+            createMockChannel("Closed Channel 2", "2025-06-15 09:30:00", "2025-06-15 11:30:00", 30)
+    );
+
+    given(channelRepository.findByChannelHostId(eq(hostId), startDateCaptor.capture(), endDateCaptor.capture(), eq(ChannelStatus.CHANNEL_STATUS_CLOSED)))
+            .willReturn(mockChannels);
+
+    // when
+    List<PlayTimeResponse> playTimeResponses = userService.getPlaytime(hostId, year);
+
+    // then
+    assertThat(playTimeResponses).hasSize(2);
+
+    PlayTimeResponse playTimeResponse1 = playTimeResponses.get(0);
+    assertThat(playTimeResponse1.getTotalPlayTime()).isEqualTo("2시간 0분");
+    assertThat(playTimeResponse1.getTotalParticipant()).isEqualTo(50);
+    assertThat(playTimeResponse1.getTotalFollowers()).isZero();
+
+    PlayTimeResponse playTimeResponse2 = playTimeResponses.get(1);
+    assertThat(playTimeResponse2.getTotalPlayTime()).isEqualTo("2시간 0분");
+    assertThat(playTimeResponse2.getTotalParticipant()).isEqualTo(30);
+    assertThat(playTimeResponse2.getTotalFollowers()).isZero();
+
+    Timestamp capturedStartDate = startDateCaptor.getValue();
+    Timestamp capturedEndDate = endDateCaptor.getValue();
+    assertThat(capturedStartDate.toLocalDateTime().getYear()).isEqualTo(year);
+    assertThat(capturedEndDate.toLocalDateTime().getYear()).isEqualTo(year + 1);
+  }
+
+  private Channel createMockChannel(String name, String startDateTime, String endDateTime, int participantCount) {
+    return Channel.builder()
+            .channelName(name)
+            .channelStatus(ChannelStatus.CHANNEL_STATUS_CLOSED)
+            .channelCreatedAt(Timestamp.valueOf(startDateTime))
+            .channelFinishedAt(Timestamp.valueOf(endDateTime))
+            .channelLastParticipantCount(participantCount)
+            .build();
   }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 
 import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
-import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
 import com.zerobase.plistbackend.module.user.dto.response.PlayTimeResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
@@ -19,7 +18,6 @@ import com.zerobase.plistbackend.module.user.type.UserErrorStatus;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import com.zerobase.plistbackend.module.user.util.S3Util;
 
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,10 +137,10 @@ public class UserServiceTest {
     Channel channel2 = mock(Channel.class);
 
     given(channel1.getChannelLastParticipantCount()).willReturn(30);
-    given(channel1.getTotalPlaytimeOfMinutes()).willReturn(3600L);
+    given(channel1.getTotalPlaytimeOfSeconds()).willReturn(3600L);
 
     given(channel2.getChannelLastParticipantCount()).willReturn(20);
-    given(channel2.getTotalPlaytimeOfMinutes()).willReturn(7200L);
+    given(channel2.getTotalPlaytimeOfSeconds()).willReturn(7200L);
 
     List<Channel> channels = List.of(channel1, channel2);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 호스트 플리방 이력 정보 조회 기능 부재

**TO-BE**

- 호스트 플리방 이력 정보를 연도별로 조회
    -  연도로 검색 -> 총 플리방 재생시간, 총 참여자 수, 해당 호스트의 팔로워 수(기능 추가시 개발 예정)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
