### PR TITLE
fix : FileInputStream 의 경로가 JAR 파일에서는 인식을 하지못해서 ClassPathResource를 통해…

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/common/app/config/FirebaseConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/common/app/config/FirebaseConfig.java
@@ -4,18 +4,19 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 @Configuration
 public class FirebaseConfig {
 
   @Bean
   public FirebaseMessaging firebaseMessaging() throws IOException {
-    FileInputStream serviceAccount = new FileInputStream(
-        "src/main/resources/firebase-service-account.json");
+    InputStream serviceAccount = new ClassPathResource(
+        "firebase-service-account.json").getInputStream();
 
     FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(serviceAccount)).build();


### PR DESCRIPTION
… firebase 설정 파일 불러오도록 변경

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 배포서버에서 파이어베이스 설정 json 파일 불러오지 못하는 이슈 발생

**TO-BE**
- ClassPathResouce를 이용해서 파일 불러오기
  - 문제 : JAR 파일은 FileInputStream의 경로 파일을 가져오지 못함.
  - 해결 : ClassPathResoure를 통해 classpath를 지정하여 파일을 불러옴.
 
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
