### PR TITLE
Feat/other profile 회원 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -62,7 +62,5 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
       @Param("channelStatus") ChannelStatus channelStatus
   );
 
-  @Query("SELECT COUNT(c) > 0 FROM Channel c WHERE c.channelHost.userId = :userId AND c.channelStatus = :status")
-  boolean existsStatusChannelByUserId(@Param("userId") Long userId,
-      @Param("status") ChannelStatus status);
+  boolean existsByChannelHost_UserIdAndChannelStatus(Long userId, ChannelStatus status);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/repository/ChannelRepository.java
@@ -4,8 +4,6 @@ import com.zerobase.plistbackend.module.channel.entity.Channel;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.user.entity.User;
 import jakarta.persistence.LockModeType;
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -52,15 +50,19 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
   Optional<Channel> findByIdFetchJoinPlaylist(@Param("channelId") Long channelId);
 
   @Query("SELECT c FROM Channel c " +
-          "JOIN FETCH c.channelHost " +
-          "WHERE c.channelHost.userId = :hostId " +
-          "AND c.channelStatus = :channelStatus " +
-          "AND c.channelCreatedAt >= :startDate " +
-          "AND c.channelCreatedAt < :endDate")
+      "JOIN FETCH c.channelHost " +
+      "WHERE c.channelHost.userId = :hostId " +
+      "AND c.channelStatus = :channelStatus " +
+      "AND c.channelCreatedAt >= :startDate " +
+      "AND c.channelCreatedAt < :endDate")
   List<Channel> findByChannelHostId(
-          @Param("hostId") Long hostId,
-          @Param("startDate") LocalDateTime startDate,
-          @Param("endDate") LocalDateTime endDate,
-          @Param("channelStatus") ChannelStatus channelStatus
+      @Param("hostId") Long hostId,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("channelStatus") ChannelStatus channelStatus
   );
+
+  @Query("SELECT COUNT(c) > 0 FROM Channel c WHERE c.channelHost.userId = :userId AND c.channelStatus = :status")
+  boolean existsStatusChannelByUserId(@Param("userId") Long userId,
+      @Param("status") ChannelStatus status);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/zerobase/plistbackend/module/subscribe/repository/SubscribeRepository.java
@@ -25,4 +25,6 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
           + "FROM Subscribe s "
           + "WHERE s.followee.userId = :followeeId")
   List<Long> findFollowersIdByFolloweeId(Long followeeId);
+
+  int countByFollower(User follower);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
       "/v3/api/channels",
       "/v3/api/channels/popular",
       "/v3/api/channels/search",
-      "/v3/api/channels/category/**"
+      "/v3/api/channels/category/**",
+      "/v3/api/user/profile/*"
   );
 
   private static final List<String> CORS_URLS = List.of(new String[]{

--- a/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.zerobase.plistbackend.module.user.controller;
 
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
 import com.zerobase.plistbackend.module.user.dto.response.HostPlaytimeResponse;
+import com.zerobase.plistbackend.module.user.dto.response.OtherProfileResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 import com.zerobase.plistbackend.module.user.dto.response.UserPlaytimeResponse;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
@@ -12,7 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -23,11 +31,18 @@ public class UserController {
 
   private final UserServiceImpl userService;
 
-  @Operation(summary = "회원 정보 조회", description = "해당 회원의 정보를 조회할 수 있습니다.")
+  @Operation(summary = "내 정보 조회", description = "로그인된 회원의 정보를 조회할 수 있습니다.")
   @GetMapping("/user/profile")
-  public ResponseEntity<ProfileResponse> findProfile(
+  public ResponseEntity<ProfileResponse> findMyProfile(
       @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
     return ResponseEntity.ok(userService.findProfile(customOAuth2User.findEmail()));
+  }
+
+  @Operation(summary = "다른 회원 정보 조회", description = "요청한 회원의 정보를 조회할 수 있습니다.")
+  @GetMapping("/user/profile/{userId}")
+  public ResponseEntity<OtherProfileResponse> findOtherProfile(
+      @PathVariable Long userId) {
+    return ResponseEntity.ok(userService.findUserIdProfile(userId));
   }
 
   @Operation(summary = "회원 탈퇴", description = "해당 회원의 탈퇴를 진행할 수 있습니다.")
@@ -47,25 +62,27 @@ public class UserController {
 
     UserProfileRequest userProfileRequest = new UserProfileRequest(file, nickName);
     userProfileRequest.validate();
-    return ResponseEntity.ok(userService.editProfile(userProfileRequest, customOAuth2User.findId()));
+    return ResponseEntity.ok(
+        userService.editProfile(userProfileRequest, customOAuth2User.findId()));
   }
+
   @Operation(summary = "회원의 플리방 이력 정보 가져오기",
-          description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
-                  " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
+      description = "연도별 호스트 재생 시간, 전체 참여자수, 팔로워 수(팔로워 수는 기능이 완료되면 추가 예정)," +
+          " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
   @GetMapping("/me/playtime/host")
   public ResponseEntity<HostPlaytimeResponse> getHistoryOfHost(
-          @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-          @RequestParam("year") int year) {
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @RequestParam("year") int year) {
     return ResponseEntity.ok(userService.getHistoryOfHost(customOAuth2User.findId(), year));
   }
 
   @Operation(summary = "회원의 플리방 이력 정보 가져오기",
-          description = "연도별 플리방 이용시간" +
-                  " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
+      description = "연도별 플리방 이용시간" +
+          " 쿼리 스트링으로 년도만 입력 ex)2024 입력시 2024~2025 데이터 추출")
   @GetMapping("/me/playtime/user")
   public ResponseEntity<UserPlaytimeResponse> getHistoryOfUser(
-          @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-          @RequestParam("year") int year) {
+      @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+      @RequestParam("year") int year) {
     return ResponseEntity.ok(userService.getHistoryOfUser(customOAuth2User.findId(), year));
   }
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/dto/response/OtherProfileResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/dto/response/OtherProfileResponse.java
@@ -1,0 +1,26 @@
+package com.zerobase.plistbackend.module.user.dto.response;
+
+import com.zerobase.plistbackend.module.user.entity.User;
+
+public record OtherProfileResponse(
+    Long userId,
+    String userName,
+    String image,
+    int followers,
+    boolean isSubscribe,
+    boolean isLive) {
+
+  public static OtherProfileResponse createOtherProfileResponse(
+      User user, int followers, boolean isSubscribe, boolean isLive) {
+
+    return new OtherProfileResponse(
+        user.getUserId(),
+        user.getUserName(),
+        user.getUserImage(),
+        followers,
+        isSubscribe,
+        isLive
+    );
+  }
+
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/dto/response/ProfileResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/dto/response/ProfileResponse.java
@@ -1,3 +1,21 @@
 package com.zerobase.plistbackend.module.user.dto.response;
 
-public record ProfileResponse (String email, String nickname, String image){}
+import com.zerobase.plistbackend.module.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileResponse {
+
+  private final String email;
+  private final String nickname;
+  private final String image;
+  private final int followers;
+
+
+  public static ProfileResponse createProfileResponse(User user, int followers) {
+    return new ProfileResponse(user.getUserEmail(), user.getUserName(), user.getUserImage(),
+        followers);
+  }
+}

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserService.java
@@ -2,16 +2,19 @@ package com.zerobase.plistbackend.module.user.service;
 
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
 import com.zerobase.plistbackend.module.user.dto.response.HostPlaytimeResponse;
+import com.zerobase.plistbackend.module.user.dto.response.OtherProfileResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 
 
 public interface UserService {
 
-   ProfileResponse findProfile(String accessToken);
+  ProfileResponse findProfile(String accessToken);
 
-   void withdrawUser(Long userId);
+  OtherProfileResponse findUserIdProfile(Long userId);
 
-   ProfileResponse editProfile(UserProfileRequest request, Long userId);
+  void withdrawUser(Long userId);
 
-   HostPlaytimeResponse getHistoryOfHost(Long hostId, int year);
+  ProfileResponse editProfile(UserProfileRequest request, Long userId);
+
+  HostPlaytimeResponse getHistoryOfHost(Long hostId, int year);
 }

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
@@ -14,7 +14,6 @@ import com.zerobase.plistbackend.module.user.dto.response.UserPlaytimeResponse;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.exception.UserException;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
-import com.zerobase.plistbackend.module.user.model.auth.UserDetail;
 import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import com.zerobase.plistbackend.module.user.type.UserErrorStatus;
 import com.zerobase.plistbackend.module.user.type.UserRole;
@@ -60,10 +59,11 @@ public class UserServiceImpl implements UserService {
         .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
 
     int followerCount = subscribeRepository.countByFollower(user);
-    boolean isLive = channelRepository.existsStatusChannelByUserId(userId,
+    boolean isLive = channelRepository.existsByChannelHost_UserIdAndChannelStatus(userId,
         ChannelStatus.CHANNEL_STATUS_ACTIVE);
     boolean isSubscribe = isSubscribe(user);
-    return OtherProfileResponse.createOtherProfileResponse(user, followerCount, isSubscribe, isLive);
+    return OtherProfileResponse.createOtherProfileResponse(user, followerCount, isSubscribe,
+        isLive);
   }
 
   boolean isSubscribe(User follower) {

--- a/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/service/UserServiceImpl.java
@@ -5,103 +5,140 @@ import com.zerobase.plistbackend.module.channel.repository.ChannelRepository;
 import com.zerobase.plistbackend.module.channel.type.ChannelStatus;
 import com.zerobase.plistbackend.module.participant.entity.Participant;
 import com.zerobase.plistbackend.module.participant.repository.ParticipantRepository;
+import com.zerobase.plistbackend.module.subscribe.repository.SubscribeRepository;
 import com.zerobase.plistbackend.module.user.dto.request.UserProfileRequest;
 import com.zerobase.plistbackend.module.user.dto.response.HostPlaytimeResponse;
+import com.zerobase.plistbackend.module.user.dto.response.OtherProfileResponse;
 import com.zerobase.plistbackend.module.user.dto.response.ProfileResponse;
 import com.zerobase.plistbackend.module.user.dto.response.UserPlaytimeResponse;
 import com.zerobase.plistbackend.module.user.entity.User;
 import com.zerobase.plistbackend.module.user.exception.UserException;
+import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
+import com.zerobase.plistbackend.module.user.model.auth.UserDetail;
 import com.zerobase.plistbackend.module.user.repository.UserRepository;
 import com.zerobase.plistbackend.module.user.type.UserErrorStatus;
 import com.zerobase.plistbackend.module.user.type.UserRole;
 import com.zerobase.plistbackend.module.user.util.S3Util;
 import com.zerobase.plistbackend.module.user.util.TimeValueFormatter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-    private final ParticipantRepository participantRepository;
-    private final UserRepository userRepository;
-    private final ChannelRepository channelRepository;
-    private final S3Util s3Util;
 
-    @Override
-    @Transactional(readOnly = true)
-    public ProfileResponse findProfile(String email) {
-        log.info("Find Profile Request email: {}", email);
-        return userRepository.findProfileByEmail(email);
+  private final ParticipantRepository participantRepository;
+  private final UserRepository userRepository;
+  private final ChannelRepository channelRepository;
+  private final S3Util s3Util;
+  private final SubscribeRepository subscribeRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public ProfileResponse findProfile(String email) {
+    log.info("Find Profile Request email: {}", email);
+    User user = userRepository.findByUserEmail(email);
+    int followers = subscribeRepository.countByFollower(user);
+    return ProfileResponse.createProfileResponse(user, followers);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public OtherProfileResponse findUserIdProfile(Long userId) {
+
+    log.info("Find Profile Request userId: {}", userId);
+
+    User user = userRepository.findByUserId(userId)
+        .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
+
+    int followerCount = subscribeRepository.countByFollower(user);
+    boolean isLive = channelRepository.existsStatusChannelByUserId(userId,
+        ChannelStatus.CHANNEL_STATUS_ACTIVE);
+    boolean isSubscribe = isSubscribe(user);
+    return OtherProfileResponse.createOtherProfileResponse(user, followerCount, isSubscribe, isLive);
+  }
+
+  boolean isSubscribe(User follower) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+      return false;
     }
+    CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    User followee = userRepository.findByUserId(customOAuth2User.findId())
+        .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
+    return subscribeRepository.existsByFolloweeAndFollower(followee, follower);
+  }
 
-    @Override
-    @Transactional
-    public void withdrawUser(Long userId) {
-        log.info("Withdraw Request userId: {}", userId);
-        User user = findUser(userId);
-        user.updateRole(UserRole.ROLE_NONE);
+  @Override
+  @Transactional
+  public void withdrawUser(Long userId) {
+    log.info("Withdraw Request userId: {}", userId);
+    User user = findUser(userId);
+    user.updateRole(UserRole.ROLE_NONE);
+  }
+
+  @Override
+  @Transactional
+  public ProfileResponse editProfile(UserProfileRequest request, Long userId) {
+
+    log.info("updateProfile Request userId: {}", userId);
+    User user = findUser(userId);
+
+    if (request.nickname() != null) {
+      user.updateUserName(request.nickname());
     }
-
-    @Override
-    @Transactional
-    public ProfileResponse editProfile(UserProfileRequest request, Long userId) {
-
-        log.info("updateProfile Request userId: {}", userId);
-        User user = findUser(userId);
-
-        if (request.nickname() != null) {
-            user.updateUserName(request.nickname());
-        }
-        if (request.image() != null) {
-            user.updateImage(s3Util.putImage(request.image(), user.getUserEmail()));
-        }
-        return new ProfileResponse(user.getUserEmail(), user.getUserName(), user.getUserImage());
+    if (request.image() != null) {
+      user.updateImage(s3Util.putImage(request.image(), user.getUserEmail()));
     }
+    return ProfileResponse.createProfileResponse(user, subscribeRepository.countByFollower(user));
+  }
 
-    private User findUser(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
-    }
+  private User findUser(Long id) {
+    return userRepository.findById(id)
+        .orElseThrow(() -> new UserException(UserErrorStatus.USER_NOT_FOUND));
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public HostPlaytimeResponse getHistoryOfHost(Long hostId, int year) {
-        List<Channel> channels = channelRepository.findByChannelHostId(
-                hostId,
-                LocalDate.of(year, 1, 1).atStartOfDay(),
-                LocalDate.of(year + 1, 1, 1).atStartOfDay(),
-                ChannelStatus.CHANNEL_STATUS_CLOSED
-        );
+  @Override
+  @Transactional(readOnly = true)
+  public HostPlaytimeResponse getHistoryOfHost(Long hostId, int year) {
+    List<Channel> channels = channelRepository.findByChannelHostId(
+        hostId,
+        LocalDate.of(year, 1, 1).atStartOfDay(),
+        LocalDate.of(year + 1, 1, 1).atStartOfDay(),
+        ChannelStatus.CHANNEL_STATUS_CLOSED
+    );
 
-        return HostPlaytimeResponse.builder()
-                .totalPlayTime(
-                        TimeValueFormatter.formatToString(
-                                channels.stream()
-                                        .mapToLong(Channel::getTotalPlaytimeOfSeconds)
-                                        .sum())
-                )
-                .totalParticipant(
-                        channels.stream().
-                                mapToInt(Channel::getChannelLastParticipantCount)
-                                .sum())
-                .totalFollowers(0L)  // 팔로워 기능 추가 예정
-                .build();
-    }
+    return HostPlaytimeResponse.builder()
+        .totalPlayTime(
+            TimeValueFormatter.formatToString(
+                channels.stream()
+                    .mapToLong(Channel::getTotalPlaytimeOfSeconds)
+                    .sum())
+        )
+        .totalParticipant(
+            channels.stream().
+                mapToInt(Channel::getChannelLastParticipantCount)
+                .sum())
+        .totalFollowers(0L)  // 팔로워 기능 추가 예정
+        .build();
+  }
 
-    public UserPlaytimeResponse getHistoryOfUser(Long userId, int year) {
-        long totalSeconds = participantRepository.findByUserIdAndDate(userId,
-                        LocalDate.of(year, 1, 1).atStartOfDay(),
-                        LocalDate.of(year + 1, 1, 1).atStartOfDay())
-                .stream()
-                .mapToLong(Participant::getTotalPlaytimeOfSeconds)
-                .sum();
-        return UserPlaytimeResponse.from(TimeValueFormatter.formatToString(totalSeconds));
+  public UserPlaytimeResponse getHistoryOfUser(Long userId, int year) {
+    long totalSeconds = participantRepository.findByUserIdAndDate(userId,
+            LocalDate.of(year, 1, 1).atStartOfDay(),
+            LocalDate.of(year + 1, 1, 1).atStartOfDay())
+        .stream()
+        .mapToLong(Participant::getTotalPlaytimeOfSeconds)
+        .sum();
+    return UserPlaytimeResponse.from(TimeValueFormatter.formatToString(totalSeconds));
 
-    }
+  }
 }

--- a/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/user/service/UserServiceTest.java
@@ -74,17 +74,15 @@ class UserServiceTest {
   @DisplayName("유저 정보 찾기 성공")
   void testFindProfileSuccess() {
     String email = "test@example.com";
-    ProfileResponse response = new ProfileResponse("test@example.com", "Test User",
-        "test-image-url");
-    when(userRepository.findProfileByEmail(email)).thenReturn(response);
+    when(userRepository.findByUserEmail(email)).thenReturn(mockUser);
 
     ProfileResponse actualResponse = userService.findProfile(email);
 
-    assertEquals(email, actualResponse.email());
-    assertEquals("Test User", actualResponse.nickname());
-    assertEquals("test-image-url", actualResponse.image());
+    assertEquals(email, actualResponse.getEmail());
+    assertEquals("Test User", actualResponse.getNickname());
+    assertEquals("test-image-url", actualResponse.getImage());
 
-    verify(userRepository).findProfileByEmail(email);
+    verify(userRepository).findByUserEmail(email);
   }
 
   @Test
@@ -107,8 +105,8 @@ class UserServiceTest {
     ProfileResponse response = userService.editProfile(request, userId);
 
     // Then
-    assertEquals("Updated User", response.nickname());
-    assertEquals("updated-image-url", response.image());
+    assertEquals("Updated User", response.getNickname());
+    assertEquals("updated-image-url", response.getImage());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존 내 정보 조회 정보 미흡
```java
{
  "email": "string",
  "nickname": "string",
  "image": "string"
}
```
- 다른 회원 정보 조회 기능 부재

**TO-BE**
- 내 정보 조회 정보 추가 - `[GET] /v3/api/user/profile`
```java
{
  "email": "string",
  "nickname": "string",
  "image": "string",
  "followers": 0
}
```
- 다른 회원 정보 조회 기능 추가 - `[GET] /v3/api/user/profile/{userId}`
```java
{
  "userId": 0,
  "userName": "string",
  "image": "string",
  "followers": 0,
  "isSubscribe": true,
  "isLive": true
}
```
로그인 되어 있는 경우 `isSubscribe` 값 확인 후 반환
로그인 되어 있지 않은 경우 `isSubscribe` 확인 작업 없이 `false` 반환

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
 - 로그인 상태 내 정보 조회 - 기대한 결과값 일치
 - 비로그인 상태 내 정보 조회 - 401 에러 반환
 - 로그인/비로그인 상태 다른 회원 정보 조회 기대한 결과값 일치