### PR TITLE
Feat/other channel 다른 회원 과거 호스트 채널 내역 조회 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/plistbackend/module/channel/controller/ChannelController.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/controller/ChannelController.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.channel.dto.request.ChannelRequest;
 import com.zerobase.plistbackend.module.channel.dto.response.ClosedChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.DetailChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.DetailClosedChannelResponse;
+import com.zerobase.plistbackend.module.channel.dto.response.OtherClosedChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.StreamingChannelResponse;
 import com.zerobase.plistbackend.module.channel.service.ChannelService;
 import com.zerobase.plistbackend.module.channel.util.ControllerApiResponse;
@@ -265,6 +266,23 @@ public class ChannelController {
 
     Slice<ClosedChannelResponse> closedChannelResponsesList = channelService.findUserChannelHistory(
         customOAuth2User, cursorId, pageable);
+
+    return ResponseEntity.ok(new ControllerApiResponse<>(closedChannelResponsesList.getContent(),
+        closedChannelResponsesList.hasNext()));
+  }
+
+  @Operation(
+      summary = "특정 회원 과거 호스트 내역 전체조회",
+      description = "특정 회원의 과거 호스트 내역을 전체조회합니다. 정렬은 최신순입니다."
+  )
+  @GetMapping("/user/other/history/{userId}")
+  public ResponseEntity<ControllerApiResponse<OtherClosedChannelResponse>> findOtherChannelHistory(
+      @RequestParam(value = "cursorId", required = false) Long cursorId,
+      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable,
+      @PathVariable Long userId) {
+
+    Slice<OtherClosedChannelResponse> closedChannelResponsesList = channelService.findOtherUserChannelHistory(
+        cursorId, pageable, userId);
 
     return ResponseEntity.ok(new ControllerApiResponse<>(closedChannelResponsesList.getContent(),
         closedChannelResponsesList.hasNext()));

--- a/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/OtherClosedChannelResponse.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/dto/response/OtherClosedChannelResponse.java
@@ -1,0 +1,24 @@
+package com.zerobase.plistbackend.module.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OtherClosedChannelResponse {
+
+  private final Long channelId;
+  private final String channelName;
+  private final String channelCategoryName;
+  private final String channelThumbnail;
+  private final String channelCreatedAt;
+
+  public OtherClosedChannelResponse(ClosedChannelResponse closedChannelResponse) {
+    this.channelId = closedChannelResponse.getChannelId();
+    this.channelName = closedChannelResponse.getChannelName();
+    this.channelCategoryName = closedChannelResponse.getChannelName();
+    this.channelThumbnail = closedChannelResponse.getChannelThumbnail();
+    this.channelCreatedAt = closedChannelResponse.getChannelCreatedAt();
+  }
+
+}

--- a/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelService.java
+++ b/src/main/java/com/zerobase/plistbackend/module/channel/service/ChannelService.java
@@ -4,6 +4,7 @@ import com.zerobase.plistbackend.module.channel.dto.request.ChannelRequest;
 import com.zerobase.plistbackend.module.channel.dto.response.ClosedChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.DetailChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.DetailClosedChannelResponse;
+import com.zerobase.plistbackend.module.channel.dto.response.OtherClosedChannelResponse;
 import com.zerobase.plistbackend.module.channel.dto.response.StreamingChannelResponse;
 import com.zerobase.plistbackend.module.user.model.auth.CustomOAuth2User;
 import com.zerobase.plistbackend.module.userplaylist.dto.request.VideoRequest;
@@ -41,6 +42,8 @@ public interface ChannelService {
   Slice<StreamingChannelResponse> findChannelListPopular(Long cursorId, Long cursorPopular, Pageable pageable);
 
   Slice<ClosedChannelResponse> findUserChannelHistory(CustomOAuth2User customOAuth2User, Long cursorId, Pageable pageable);
+
+  Slice<OtherClosedChannelResponse> findOtherUserChannelHistory(Long cursorId, Pageable pageable, Long userId);
 
   void likeVideo(CustomOAuth2User customOAuth2User, VideoRequest videoRequest);
 

--- a/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
@@ -50,7 +51,8 @@ public class SecurityConfig {
       "/v3/api/channels/popular",
       "/v3/api/channels/search",
       "/v3/api/channels/category/**",
-      "/v3/api/user/profile/*"
+      "/v3/api/user/profile/*",
+      "/v3/api/user/other/history/*"
   );
 
   private static final List<String> CORS_URLS = List.of(new String[]{

--- a/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/plistbackend/module/user/config/SecurityConfig.java
@@ -22,7 +22,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
@@ -42,7 +41,7 @@ public class SecurityConfig {
       "/", "index.html",
       "/ws-connect/**",
       "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/error",
-      "/sc","/env", "/actuator/**"
+      "/sc", "/env", "/actuator/**"
   };
 
   private static final List<String> PUBLIC_GET_URLS = List.of(

--- a/src/test/java/com/zerobase/plistbackend/module/channel/controller/ChannelControllerTest.java
+++ b/src/test/java/com/zerobase/plistbackend/module/channel/controller/ChannelControllerTest.java
@@ -1,0 +1,81 @@
+package com.zerobase.plistbackend.module.channel.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zerobase.plistbackend.module.channel.dto.response.OtherClosedChannelResponse;
+import com.zerobase.plistbackend.module.channel.service.ChannelService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ChannelController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class ChannelControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ChannelService channelService;
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    public ChannelService channelService() {
+      return Mockito.mock(ChannelService.class);
+    }
+  }
+
+  @Test
+  @DisplayName("특정 회원의 과거 채널 히스토리를 조회")
+  void testFindOtherChannelHistory() throws Exception {
+    // given
+    Long userId = 1L;
+    Long cursorId = null;
+    Pageable pageable = PageRequest.of(0, 20);
+
+    OtherClosedChannelResponse response = new OtherClosedChannelResponse(
+        2L,
+        "string",
+        "string",
+        "",
+        "2025-04-08T00:51:19"
+    );
+
+    List<OtherClosedChannelResponse> responseList = List.of(response);
+    Slice<OtherClosedChannelResponse> slice = new SliceImpl<>(responseList, pageable, false);
+
+    given(channelService.findOtherUserChannelHistory(cursorId, pageable, userId))
+        .willReturn(slice);
+
+    // when & then
+    mockMvc.perform(get("/v3/api/user/other/history/{userId}", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].channelId").value(2))
+        .andExpect(jsonPath("$.content[0].channelName").value("string"))
+        .andExpect(jsonPath("$.content[0].channelCategoryName").value("string"))
+        .andExpect(jsonPath("$.content[0].channelThumbnail").value(""))
+        .andExpect(jsonPath("$.content[0].channelCreatedAt").value("2025-04-08T00:51:19"))
+        .andExpect(jsonPath("$.hasNext").value(false));
+  }
+
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
다른 회원의 채널 호스트 이력 조회 기능 부재

**TO-BE**
- 다른 회원의 채널 호스트 이력 조회 - `[GET] /v3/api/user/other/history/{userId}`
```
{
    "content": [
        {
            "channelId": 2,
            "channelName": "string",
            "channelCategoryName": "string",
            "channelThumbnail": "",
            "channelCreatedAt": "2025-04-08T00:51:19"
        }
    ],
    "hasNext": false
}
```

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- 요청 후 기대값 확인
- [x] API 테스트
- 로그인 없이 조회 성공
